### PR TITLE
fix evil-up-block

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1375,48 +1375,41 @@ match-data reflects the last successful match (that caused COUNT
 to reach zero). The behaviour of this functions is similar to
 `up-list'."
   (let* ((count (or count 1))
-         (dir (if (> count 0) +1 -1)))
+         (forwardp (> count 0))
+         (dir (if forwardp +1 -1)))
     (catch 'done
       (while (not (zerop count))
         (let* ((pnt (point))
                (cl (save-excursion
-                     (and (re-search-forward end nil t dir)
+                     (and (re-search-forward (if forwardp end beg) nil t dir)
                           (or (/= pnt (point))
                               (progn
                                 ;; zero size match, repeat search from
                                 ;; the next position
                                 (forward-char dir)
-                                (re-search-forward end nil t dir)))
+                                (re-search-forward (if forwardp end beg) nil t dir)))
                           (point))))
                (match (match-data t))
                (op (save-excursion
-                     (and (re-search-forward beg cl t dir)
+                     (and (re-search-forward (if forwardp beg end) cl t dir)
                           (or (/= pnt (point))
                               (progn
                                 ;; zero size match, repeat search from
                                 ;; the next position
                                 (forward-char dir)
-                                (re-search-forward beg cl t dir)))
+                                (re-search-forward (if forwardp beg end) cl t dir)))
                           (point)))))
           (cond
-           ((and (not op) (not cl))
-            (goto-char (if (> dir 0) (point-max) (point-min)))
+           ((not cl)
+            (goto-char (if forwardp (point-max) (point-min)))
             (set-match-data nil)
             (throw 'done count))
-           ((> dir 0)
-            (if cl
-                (progn
-                  (setq count (1- count))
-                  (if (zerop count) (set-match-data match))
-                  (goto-char cl))
-              (setq count (1+ count))
-              (goto-char op)))
-           ((< dir 0)
+           (t
             (if op
                 (progn
-                  (setq count (1+ count))
+                  (setq count (if forwardp (1+ count) (1- count)))
                   (goto-char op))
-              (setq count (1- count))
+              (setq count (if forwardp (1- count) (1+ count)))
               (if (zerop count) (set-match-data match))
               (goto-char cl))))))
       0)))


### PR DESCRIPTION

This fixes issues with text objects. For example, if we run the code:

    (evil-define-text-object inner-racket-comment (count &optional beg end type)
      (evil-select-paren "#|" "|#" beg end type count nil))
    (evil-define-text-object outer-racket-comment (count &optional beg end type)
      (evil-select-paren "#|" "|#" beg end type count t))

    (define-key evil-inner-text-objects-map "#" 'inner-racket-comment)
    (define-key evil-outer-text-objects-map "#" 'outer-racket-comment)

then we go to some text like this (where ? will represent the cursor position):

    #|this is? a test #|with rackety|# multiline
      and nestable comments|#

then hit vi# we get the following (with < and > denoting the visual range endings)

    #|this is a test #|<with rackety>|# multiline
      and nestable comments|#

This patch makes it work as expected, so the range is:

    #|<this is a test #|with rackety|# multiline
      and nestable comments>|#

The patch passes all the tests run by make terminal, and from a bit of general use with the patch on everything seems fine.

Thanks
