### PR TITLE
Prevent warning when accessing search history

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -76,6 +76,7 @@ search module is used."
 
 (defun evil-search-incrementally (forward regexp-p)
   "Search incrementally for user-entered text."
+  (make-local-variable 'isearch-search-fun-function)
   (let ((evil-search-prompt (evil-search-prompt forward))
         (isearch-search-fun-function 'evil-isearch-function)
         (point (point))


### PR DESCRIPTION
Making a variable buffer-local within the BODY of a `let` generates a warning if that variable is currently let-bound (i.e. it appeared in the `let` VARLIST). Such warnings are only issued once per symbol, in order to avoid harassing the user too much.

Within evil-search-incrementally, `'isearch-search-fun-function` is let-bound, and within the body of the `let`, isearch makes that same variable buffer-local (see minibuffer-history-isearch-setup). As a result, upon starting Emacs in evil-mode, the first time you attempt a search (`/`), accessing the search history (`M-p`) causes the following warning to display in the echo area:

> Making isearch-search-fun-function local to *Minibuf-1* while let-bound!

Subsequent searches are unaffected, since these warnings are only displayed once per symbol. If the first search doesn't try to access search history, it too is unaffected.

This was reproducible with a minimal init.el

```elisp
(package-initialize)
(require 'evil)
(add-hook 'after-init-hook #'evil-mode)
```

and the following steps:
 - start Emacs
 - type `/`
 - type `M-p`

See issue #748 
#### Proposed fix

This change prevents such warnings by making `'isearch-search-fun-function` buffer-local before entering the `let` in evil-search-incrementally.

#### Screenshot

![](https://cloud.githubusercontent.com/assets/1672874/22362005/44e48fac-e42d-11e6-80d0-1a18dc595e4d.png)