### PR TITLE
Fix for append from visual state

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2187,6 +2187,7 @@ the lines."
           (evil-insert count vcount skip-empty-lines)))
        (t
         (evil-visual-rotate 'lower-right)
+        (backward-char)
         (evil-append count)))
     (unless (eolp) (forward-char))
     (evil-insert count vcount skip-empty-lines)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -928,6 +928,14 @@ Below some empty line"
     ("aevil rulz " [escape])
     ";; Tevil rulz[ ]his buffer is for notes you don't want to save"))
 
+(ert-deftest evil-test-visual-append ()
+  "Test `evil-append' from visual state"
+  :tags '(evil insert)
+  (evil-test-buffer
+   ";; [T]his buffer is for notes you don't want to save"
+   ("veA_evil rulz " [escape])
+   ";; This_evil rulz[ ] buffer is for notes you don't want to save"))
+
 (ert-deftest evil-test-open-above ()
   "Test `evil-open-above'"
   :tags '(evil insert)


### PR DESCRIPTION
Steps to reproduce the problem: 
1. paste to the scratch buffer 'Sample text' 
2. press `0veA11` 
3. text in the buffer: Sample 11text

Expected result: Sample11 text