### PR TITLE
Possible fix for prefix arg change in this-command-keys

### DIFF
--- a/evil-repeat.el
+++ b/evil-repeat.el
@@ -320,6 +320,16 @@ invoked the current command"
   (clear-this-command-keys t)
   (setq evil-repeat-keys ""))
 
+(defun evil-this-command-keys (&optional post-cmd)
+  "Version of `this-command-keys' with finer control over prefix args."
+  (let ((arg (if post-cmd current-prefix-arg prefix-arg)))
+    (vconcat
+     (when (and (numberp arg)
+                ;; Only add prefix if no repeat info recorded yet
+                (null evil-repeat-info))
+       (string-to-vector (number-to-string arg)))
+     (this-single-command-keys))))
+
 (defun evil-repeat-keystrokes (flag)
   "Repeation recording function for commands that are repeated by keystrokes."
   (cond
@@ -327,11 +337,11 @@ invoked the current command"
     (when evil-this-register
       (evil-repeat-record
        `(set evil-this-register ,evil-this-register)))
-    (setq evil-repeat-keys (this-command-keys)))
+    (setq evil-repeat-keys (evil-this-command-keys)))
    ((eq flag 'post)
-    (evil-repeat-record (if (zerop (length (this-command-keys)))
+    (evil-repeat-record (if (zerop (length (evil-this-command-keys t)))
                             evil-repeat-keys
-                          (this-command-keys)))
+                          (evil-this-command-keys t)))
     ;; erase commands keys to prevent double recording
     (evil-clear-command-keys))))
 


### PR DESCRIPTION
Emacs 25.1 no longer records prefix-args in this-command-keys, breaking
evil-repeat. This change tries to fix that by adding back the prefix arg when
appropriate using evil-this-command-keys.

All tests pass on my machine on Emacs 25.1 and 24.5 with this patch.

See #731