### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: generic
+sudo: false
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
+  - cask --debug
+
+env:
+  matrix:
+    - EVM_EMACS=emacs-24.3-travis
+    - EVM_EMACS=emacs-24.4-travis
+    - EVM_EMACS=emacs-24.5-travis
+    - EVM_EMACS=emacs-25.1-travis
+    - EVM_EMACS=emacs-git-snapshot-travis
+
+# FIXME: Emacs 25 segfaults when running make test.
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-25.1-travis
+    - env: EVM_EMACS=emacs-git-snapshot-travis
+
+script:
+  - emacs --version
+  - make test

--- a/Cask
+++ b/Cask
@@ -1,0 +1,6 @@
+(package "evil" "1.2.12" "Extensible Vi layer for Emacs.")
+
+(files "*.el")
+
+;; (depends-on "goto-chg" "0.6.3")
+;; (depends-on "undo-tree" "1.6")


### PR DESCRIPTION
Note that Emacs 25 segfaults when running `make test` (but it works fine when running tests in `make emacs`). I've marked them as allowed failures for this reason. At least this should help out those of us who don't want to keep 24 installed just for testing.