### PR TITLE
Add missing mention to goto-cgh in the appropriate README.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ Move Evil to `~/.emacs.d/evil`. Then add the following lines to `~/.emacs`:
 (evil-mode 1)
 ```
 
-Evil requires [undo-tree.el](http://www.emacswiki.org/emacs/UndoTree) in the
+## Dependencies
+
+* Evil requires [undo-tree.el](http://www.emacswiki.org/emacs/UndoTree) in the
 `load-path` for linear undo and undo branches.
+
+* For the motions `g;` `g,` and for the last-change-register `.`, Evil requires the
+[goto-chg.el](https://www.emacswiki.org/emacs/GotoChg) package,
+which provides the functions `goto-last-change` and `goto-last-change-reverse`.
 
 # Documentation
 


### PR DESCRIPTION
The readme mentions `undo-tree.el` as a dependency in the installation section, but misses stating the final dependency which is `goto-chg.el`.