### PR TITLE
abbrev.el integration - add customizable variable `evil-want-abbrev-expand-on-insert-exit`.

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -552,4 +552,9 @@ Based on `evil-enclose-ace-jump-for-motion'."
 
 (provide 'evil-integration)
 
+;;; abbrev.el
+(when evil-want-abbrev-expand-on-insert-exit
+  (eval-after-load 'abbrev
+    '(add-hook 'evil-insert-state-exit-hook 'expand-abbrev)))
+
 ;;; evil-integration.el ends here

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8184,6 +8184,25 @@ maybe we need one line more with some text\n")
         ("3\C-i") ;; even after jumping forward 3 times it can't get past the 3rd z
         "z z [z] z z z z z"))))
 
+(ert-deftest evil-test-abbrev-expand ()
+  :tags '(evil abbrev)
+  (ert-info ("Test abbrev expansion on insert state exit")
+    (define-abbrev-table 'global-abbrev-table
+      '(("undef" "undefined"))) ;; add global abbrev
+    (evil-test-buffer
+     "foo unde[f] bar"
+     ("a" [escape])
+     "foo undefine[d] bar") ;; 'undef' should be expanded
+    (evil-test-buffer
+     "fo[o] undef bar"
+     ("a" [escape])
+     "fo[o] undef bar") ;; 'foo' shouldn't be expanded, it's not an abbrev
+    (kill-all-abbrevs) ;; remove abbrevs
+    (evil-test-buffer
+     "foo unde[f] bar"
+     ("a" [escape])
+     "foo unde[f] bar"))) ;; 'undef' is not an abbrev, shouldn't be expanded
+
 (provide 'evil-tests)
 
 ;;; evil-tests.el ends here

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1180,6 +1180,12 @@ command is non-zero."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-want-abbrev-expand-on-insert-exit t
+  "If non-nil abbrevs will be expanded when leaving Insert state
+like in Vim. This variable is read only on load."
+  :type 'boolean
+  :group 'evil)
+
 ;;; Variables
 
 (defmacro evil-define-local-var (symbol &optional initvalue docstring)


### PR DESCRIPTION
When non-nil (which is default) the `expand-abbrev` will be called in
a `evil-insert-state-exit-hook` hook. This is in-line with Vim's behaviour.

Refs #765