### PR TITLE
Require cl-lib instead of cl

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3208,52 +3208,50 @@ must be regular expressions and `evil-up-block' is used.
 If the selection is exclusive, whitespace at the end or at the
 beginning of the selection until the end-of-line or beginning-of-line
 is ignored."
-  (lexical-let
-      ((open open) (close close))
-    ;; we need special linewise exclusive selection
-    (unless inclusive (setq inclusive 'exclusive-line))
-    (cond
-     ((and (characterp open) (characterp close))
-      (let ((thing #'(lambda (&optional cnt)
-                       (evil-up-paren open close cnt)))
-            (bnd (or (bounds-of-thing-at-point 'evil-string)
-                     (bounds-of-thing-at-point 'evil-comment)
-                     ;; If point is at the opening quote of a string,
-                     ;; this must be handled as if point is within the
-                     ;; string, i.e. the selection must be extended
-                     ;; around the string. Otherwise
-                     ;; `evil-select-block' might do the wrong thing
-                     ;; because it accidentally moves point inside the
-                     ;; string (for inclusive selection) when looking
-                     ;; for the current surrounding block. (re #364)
-                     (and (= (point) (or beg (point)))
-                          (save-excursion
-                            (goto-char (1+ (or beg (point))))
-                            (or (bounds-of-thing-at-point 'evil-string)
-                                (bounds-of-thing-at-point 'evil-comment)))))))
-        (if (not bnd)
-            (evil-select-block thing beg end type count inclusive)
-          (or (evil-with-restriction (car bnd) (cdr bnd)
-                (condition-case nil
-                    (evil-select-block thing beg end type count inclusive)
-                  (error nil)))
-              (save-excursion
-                (setq beg (or beg (point))
-                      end (or end (point)))
-                (goto-char (car bnd))
-                (let ((extbeg (min beg (car bnd)))
-                      (extend (max end (cdr bnd))))
-                  (evil-select-block thing
-                                     extbeg extend
-                                     type
-                                     count
-                                     inclusive
-                                     (or (< extbeg beg) (> extend end))
-                                     t)))))))
-     (t
-      (evil-select-block #'(lambda (&optional cnt)
-                             (evil-up-block open close cnt))
-                         beg end type count inclusive)))))
+  ;; we need special linewise exclusive selection
+  (unless inclusive (setq inclusive 'exclusive-line))
+  (cond
+   ((and (characterp open) (characterp close))
+    (let ((thing #'(lambda (&optional cnt)
+                     (evil-up-paren open close cnt)))
+          (bnd (or (bounds-of-thing-at-point 'evil-string)
+                   (bounds-of-thing-at-point 'evil-comment)
+                   ;; If point is at the opening quote of a string,
+                   ;; this must be handled as if point is within the
+                   ;; string, i.e. the selection must be extended
+                   ;; around the string. Otherwise
+                   ;; `evil-select-block' might do the wrong thing
+                   ;; because it accidentally moves point inside the
+                   ;; string (for inclusive selection) when looking
+                   ;; for the current surrounding block. (re #364)
+                   (and (= (point) (or beg (point)))
+                        (save-excursion
+                          (goto-char (1+ (or beg (point))))
+                          (or (bounds-of-thing-at-point 'evil-string)
+                              (bounds-of-thing-at-point 'evil-comment)))))))
+      (if (not bnd)
+          (evil-select-block thing beg end type count inclusive)
+        (or (evil-with-restriction (car bnd) (cdr bnd)
+              (condition-case nil
+                  (evil-select-block thing beg end type count inclusive)
+                (error nil)))
+            (save-excursion
+              (setq beg (or beg (point))
+                    end (or end (point)))
+              (goto-char (car bnd))
+              (let ((extbeg (min beg (car bnd)))
+                    (extend (max end (cdr bnd))))
+                (evil-select-block thing
+                                   extbeg extend
+                                   type
+                                   count
+                                   inclusive
+                                   (or (< extbeg beg) (> extend end))
+                                   t)))))))
+   (t
+    (evil-select-block #'(lambda (&optional cnt)
+                           (evil-up-block open close cnt))
+                       beg end type count inclusive))))
 
 (defun evil-select-quote-thing (thing beg end type count &optional inclusive)
   "Selection THING as if it described a quoted object.

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -24,8 +24,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Evil.  If not, see <http://www.gnu.org/licenses/>.
 
-(eval-when-compile (require 'cl))
-
+(require 'cl-lib)
 (require 'evil-core)
 (require 'evil-states)
 
@@ -189,7 +188,7 @@
     :entries (let* ((jumps (evil--jumps-savehist-sync))
                     (count 0))
                (cl-loop for jump in jumps
-                        collect `(nil [,(number-to-string (incf count))
+                        collect `(nil [,(number-to-string (cl-incf count))
                                        ,(number-to-string (car jump))
                                        (,(cadr jump))])))
     :select-action #'evil--show-jumps-select-action))

--- a/evil-pkg.el
+++ b/evil-pkg.el
@@ -3,4 +3,5 @@
   "1.2.12"
   "Extensible Vi layer for Emacs."
   '((undo-tree "0.6.3")
-    (goto-chg "1.6")))
+    (goto-chg "1.6")
+    (cl-lib "0.5")))

--- a/scripts/evilupdate
+++ b/scripts/evilupdate
@@ -48,7 +48,6 @@
 (require 'f)
 (require 'erc)
 (require 'yaoddmuse)
-(eval-when-compile (require 'cl))
 
 (defconst evilupdate-irc-nick "lyrobot")
 (defconst evilupdate-irc-channel "#evil-mode")


### PR DESCRIPTION
As parts of Evil have already been using `cl-loop` from `cl-lib` while others still relied on unprefixed `cl.el` functionality (more specifically, `incf`), I've taken the liberty to remove all `cl.el` usage.  A side effect of this is that Evil depends on `cl-lib` to accomodate for older Emacsen (24.1 and 24.2?) that don't have it included, for them the dependency can be installed from GNU ELPA.  This also means that code specific to Emacs 23 should be deleted as Emacs 23 isn't compatible with cl-lib and we don't test it anyways.

The biggest change is the dropped `lexical-let` from `evil-select-paren`.  I've thought for quite a while about why one would want to bind a variable to its value and came up with two cases:

1. The body of the let mutates one of the bindings which happen to refer to dynamically bound variables outside (most common example: `(let ((this-command this-command)) <code potentially changing this-command>)`).
2. The body of the let contains lambdas that close over free variables involving one of its bindings (think event handlers and alike).  This always works with lexical binding enabled as closures are created for that case which capture the free variables with their current values, creating an environment permanently attached to the lambda.  With dynamic binding, it depends.  If you immediately call the lambda, the free variables can be looked up in the calling frames and resolved meaningfully.  Calling it at a later point in time (like with `run-at-time` or from `url-retrieve`) will fail, unless you go for:
- lexical binding, be it real (by enabling it for the buffer with a file variable prop line) or emulated (with `lexical-let` from `cl.el`)
- a backquoted lambda, with the free variables unquoted into it, giving you literals instead of a mutable environment

Clearly this happens to be case 2 as there are two sharp-quoted lambdas referring to the let-bound variables.  As the lambda is called immediately, the call stack contains them, so neither fake lexical binding nor backquoted lambdas are needed.  This is why I've removed the `lexical-let` altogether.  Even better, if we ever switch to true lexical binding, the lambdas will capture the arguments, so the code will continue working.