### PR TITLE
Match C-e/C-y scrolling behavior with Vim's

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -811,7 +811,8 @@ If COUNT is not specified the function uses
   (progn
     (setq count (or count evil-scroll-line-count))
     (setq evil-scroll-line-count count)
-    (scroll-down count)))
+    (let ((scroll-preserve-screen-position nil))
+      (scroll-down count))))
 
 (evil-define-command evil-scroll-line-down (count)
   "Scrolls the window COUNT lines downwards.
@@ -823,7 +824,8 @@ If COUNT is not specified the function uses
   (progn
     (setq count (or count evil-scroll-line-count))
     (setq evil-scroll-line-count count)
-    (scroll-up count)))
+    (let ((scroll-preserve-screen-position nil))
+      (scroll-up count))))
 
 (evil-define-command evil-scroll-count-reset ()
   "Sets `evil-scroll-count' to 0.


### PR DESCRIPTION
`scroll-preserve-screen-position' is a user settable variable that
controls scroll-up/scroll-down's behavior.

Set it to nil before calling scroll-* so that the cursor stays on the
same line it was already on after scrolling.

https://github.com/emacs-evil/evil/issues/734