### PR TITLE
Update evil-scroll-line-up and ..-down

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -801,31 +801,37 @@ on the first non-blank character."
   (back-to-indentation))
 
 ;; scrolling
-(evil-define-command evil-scroll-line-up (count)
-  "Scrolls the window COUNT lines upwards.
-If COUNT is not specified the function uses
-`evil-scroll-line-count', which is the last used count."
+(evil-define-command evil-scroll-line-up (&optional count)
+  "Scrolls the window one or COUNT lines upwards.
+If COUNT isn't specified, then the last used COUNT
+is read from the `evil-scroll-line-count' variable.
+If COUNT is negative, then it scrolls downwards.
+If COUNT is 0, then it gets reset to 1."
   :repeat nil
   :keep-visual t
   (interactive "<c>")
-  (progn
-    (setq count (or count evil-scroll-line-count))
+  (let ((count (cond ((not count) evil-scroll-line-count)
+                     ((= count 0) 1)
+                     (t           count)))
+        (scroll-preserve-screen-position nil))
     (setq evil-scroll-line-count count)
-    (let ((scroll-preserve-screen-position nil))
-      (scroll-down count))))
+    (scroll-down count)))
 
-(evil-define-command evil-scroll-line-down (count)
-  "Scrolls the window COUNT lines downwards.
-If COUNT is not specified the function uses
-`evil-scroll-line-count', which is the last used count."
+(evil-define-command evil-scroll-line-down (&optional count)
+  "Scrolls the window one or COUNT lines downwards.
+If COUNT isn't specified, then the last used COUNT
+is read from the `evil-scroll-line-count' variable.
+If COUNT is negative, then it scrolls upwards.
+If COUNT is 0, then it gets reset to 1."
   :repeat nil
   :keep-visual t
   (interactive "<c>")
-  (progn
-    (setq count (or count evil-scroll-line-count))
+  (let ((count (cond ((not count) evil-scroll-line-count)
+                     ((= count 0) 1)
+                     (t           count)))
+        (scroll-preserve-screen-position nil))
     (setq evil-scroll-line-count count)
-    (let ((scroll-preserve-screen-position nil))
-      (scroll-up count))))
+    (scroll-up count)))
 
 (evil-define-command evil-scroll-count-reset ()
   "Sets `evil-scroll-count' to 0.


### PR DESCRIPTION
Adding an "&optional" keyword indicates that the count argument
isn't required.

The docstrings were updated to match the changes. With an addition
of stating that a negative count scrolls in the opposite direction.

A 0 count argument caused the evil-scroll-line-up / ..-down
commands to stop scrolling, this resets a 0 count argument to 1.

Resolves #778 