### PR TITLE
Look up bound key status correctly

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -743,6 +743,13 @@ filename."
   (when prompt
     (setcdr map (cons prompt (cdr map)))))
 
+(defun evil-lookup-key (map key)
+  "Returns non-nil value if KEY is bound in MAP."
+  (let ((definition (lookup-key map key)))
+    (if (numberp definition) ; in-band error
+        nil
+      definition)))
+
 ;;; Display
 
 (defun evil-set-cursor (specs)

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -29,6 +29,7 @@
 (require 'evil-ex)
 (require 'evil-commands)
 (require 'evil-command-window)
+(require 'evil-common)
 
 ;;; Code:
 
@@ -390,13 +391,13 @@ included in `evil-insert-state-bindings' by default."
      ((and remove
            (or force
                ;; Only remove if the default binding has not changed
-               (eq (lookup-key evil-insert-state-map (car binding))
+               (eq (evil-lookup-key evil-insert-state-map (car binding))
                    (cdr binding))))
       (define-key evil-insert-state-map (car binding) nil))
      ((and (null remove)
            (or force
                ;; Check to see that nothing is bound here before adding
-               (null (lookup-key evil-insert-state-map (car binding)))))
+               (not (evil-lookup-key evil-insert-state-map (car binding)))))
       (define-key evil-insert-state-map (car binding) (cdr binding))))))
 
 (define-key evil-insert-state-map [delete] 'delete-char)


### PR DESCRIPTION
A user reported on IRC that they failed at customizing Evil to *not* join lines when deleting with the backspace key.  This appears to be the fault of code in `evil-maps.el` which goes through a list of mappings, then checks whether they're bound and what they're bound to before removing or adding a binding.  While this works perfectly for nearly all cases, it fails on remapping definitions such as `([remap delete-backward-char] . evil-delete-backward-char-and-join)` as Emacs signals an in-band error by returning a number as definition.

I've taken the liberty of introducing a helper function that handles this case.  Perhaps we should look into using it in other places that go for regular `lookup-key` after merging this PR.