### PR TITLE
Add support for passing COUNT and BANG to :join

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1531,6 +1531,18 @@ but doesn't insert or remove any spaces."
       (unless (eobp)
         (delete-char 1)))))
 
+(evil-define-operator evil-ex-join (beg end &optional count bang)
+  "Join the selected lines with optional COUNT and BANG."
+  (interactive "<r><a><!>")
+  (let ((join-fn (if bang 'evil-join-whitespace 'evil-join)))
+    (cond
+     ((or (not count) (region-active-p))
+      (funcall join-fn beg end))
+     ((string-match-p "^[1-9][0-9]*$" count)
+      (funcall join-fn beg (point-at-eol (string-to-number count))))
+     (t
+      (user-error "Invalid count")))))
+
 (evil-define-operator evil-fill (beg end)
   "Fill text."
   :move-point nil

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -450,7 +450,7 @@ included in `evil-insert-state-bindings' by default."
 (evil-ex-define-cmd "d[elete]" 'evil-delete)
 (evil-ex-define-cmd "y[ank]" 'evil-yank)
 (evil-ex-define-cmd "go[to]" 'evil-goto-char)
-(evil-ex-define-cmd "j[oin]" 'evil-join)
+(evil-ex-define-cmd "j[oin]" 'evil-ex-join)
 (evil-ex-define-cmd "le[ft]" 'evil-align-left)
 (evil-ex-define-cmd "ri[ght]" 'evil-align-right)
 (evil-ex-define-cmd "ce[nter]" 'evil-align-center)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2295,7 +2295,28 @@ ABCthen enter the text in that file's own buffer.")))
     (evil-test-buffer
      "[l]ine 1\nline 2\nline 3\nline 4"
      (":join 2")
-     "line 1 line 2\nline 3\nline 4")))
+     "line 1 line 2\nline 3\nline 4"))
+  (ert-info ("Join with count and single line range")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":2join 3")
+     "line 1\nline 2 line 3 line 4"))
+  (ert-info ("Join with count and range")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":1,2join 3")
+     "line 1\nline 2 line 3 line 4"))
+  (ert-info ("Join with count, range and bang")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":1,2join! 3")
+     "line 1\nline 2line 3line 4"))
+  (ert-info ("Join with range")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":1,3join")
+     "line 1 line 2 line 3\nline 4"))
+  )
 
 (ert-deftest evil-test-substitute ()
   "Test `evil-substitute'"

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2255,7 +2255,7 @@ ABCthen enter the text in that file's own buffer.")))
 
 (ert-deftest evil-test-join ()
   "Test `evil-join'"
-  :tags '(evil operator)
+  :tags '(evil join operator)
   (ert-info ("Simple")
     (evil-test-buffer
       ";; [T]his buffer is for notes you don't want to save.
@@ -2270,7 +2270,32 @@ ABCthen enter the text in that file's own buffer.")))
 ;; If you want to create a file, visit that file with C-x C-f.>"
       ("J")
       ";; This buffer is for notes you don't want to save.[ ]\
-;; If you want to create a file, visit that file with C-x C-f.")))
+;; If you want to create a file, visit that file with C-x C-f."))
+  (ert-info ("Join with count")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":join 3")
+     "line 1 line 2 line 3\nline 4"))
+  (ert-info ("Join with bang and count")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":join! 3")
+     "line 1line 2line 3\nline 4"))
+  (ert-info ("Join with bang and count, exceeding end-of-buffer")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":join! 10")
+     "line 1line 2line 3line 4"))
+  (ert-info ("Join with count 1 should be the same as without count")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":join 1")
+     "line 1 line 2\nline 3\nline 4"))
+  (ert-info ("Join with count 2 should be the same as with count 1")
+    (evil-test-buffer
+     "[l]ine 1\nline 2\nline 3\nline 4"
+     (":join 2")
+     "line 1 line 2\nline 3\nline 4")))
 
 (ert-deftest evil-test-substitute ()
   "Test `evil-substitute'"


### PR DESCRIPTION
This tries to fix one of the reported issues in #760 (the other one is :delete)

Also, `:join` now supports bang `!` - it was simple to add.

Edit: the second commit tries to emulate vim's behaviour.
~~However, I failed emulating vim's behaviour when both COUNT and visual range are given (). Hence I left this corner-case unchanged (seems like a corner case to *me*, but maybe some people are regularly using it) - the COUNT will be ignored if `region-active-p` is true. I personally don't find vim's behaviour intuitive, seems like they had to chose some default and went with it.~~

Let me know if the PR can be improved in any way.