### PR TITLE
Don't reuse scroll line count

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -802,30 +802,20 @@ on the first non-blank character."
 
 ;; scrolling
 (evil-define-command evil-scroll-line-up (count)
-  "Scrolls the window COUNT lines upwards.
-If COUNT is not specified the function uses
-`evil-scroll-line-count', which is the last used count."
+  "Scrolls the window COUNT lines upwards."
   :repeat nil
   :keep-visual t
-  (interactive "<c>")
-  (progn
-    (setq count (or count evil-scroll-line-count))
-    (setq evil-scroll-line-count count)
-    (let ((scroll-preserve-screen-position nil))
-      (scroll-down count))))
+  (interactive "p")
+  (let ((scroll-preserve-screen-position nil))
+    (scroll-down count)))
 
 (evil-define-command evil-scroll-line-down (count)
-  "Scrolls the window COUNT lines downwards.
-If COUNT is not specified the function uses
-`evil-scroll-line-count', which is the last used count."
+  "Scrolls the window COUNT lines downwards."
   :repeat nil
   :keep-visual t
-  (interactive "<c>")
-  (progn
-    (setq count (or count evil-scroll-line-count))
-    (setq evil-scroll-line-count count)
-    (let ((scroll-preserve-screen-position nil))
-      (scroll-up count))))
+  (interactive "p")
+  (let ((scroll-preserve-screen-position nil))
+    (scroll-up count)))
 
 (evil-define-command evil-scroll-count-reset ()
   "Sets `evil-scroll-count' to 0.

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1199,12 +1199,6 @@ and `evil-scroll-down'.
 Determines how many lines should be scrolled.
 Default value is 0 - scroll half the screen.")
 
-(evil-define-local-var evil-scroll-line-count 1
-  "Holds last used prefix for `evil-scroll-line-up'
-and `evil-scroll-line-down'.
-Determines how many lines should be scrolled.
-Default value is 1 line.")
-
 (evil-define-local-var evil-state nil
   "The current Evil state.
 To change the state, use `evil-change-state'


### PR DESCRIPTION
This change has been applied to get closer to Vim.  While C-u and C-d in Vim remember the last scroll amount, the Vim manual mentions nothing of this sort about C-y and C-e.

Closes #790.