### PR TITLE
Correct C-e and C-y in replace state

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2306,6 +2306,13 @@ next VCOUNT - 1 lines below the current one."
                    (setq row nil)))
         rows))))
 
+(defun evil--self-insert-string (string)
+  "Insert STRING as if typed interactively."
+  (let ((chars (append string nil)))
+    (dolist (char chars)
+      (let ((last-command-event char))
+        (self-insert-command 1)))))
+
 (defun evil-copy-from-above (arg)
   "Copy characters from preceding non-blank line.
 The copied text is inserted before point.
@@ -2320,7 +2327,7 @@ See also \\<evil-insert-state-map>\\[evil-copy-from-below]."
      (list (prefix-numeric-value current-prefix-arg)))
     (t
      (list (prefix-numeric-value current-prefix-arg)))))
-  (insert (evil-copy-chars-from-line 1 (- arg))))
+  (evil--self-insert-string (evil-copy-chars-from-line arg -1)))
 
 (defun evil-copy-from-below (arg)
   "Copy characters from following non-blank line.
@@ -2335,7 +2342,7 @@ See also \\<evil-insert-state-map>\\[evil-copy-from-above]."
      (list (prefix-numeric-value current-prefix-arg)))
     (t
      (list (prefix-numeric-value current-prefix-arg)))))
-  (insert (evil-copy-chars-from-line 1 arg)))
+  (evil--self-insert-string (evil-copy-chars-from-line arg 1)))
 
 ;; adapted from `copy-from-above-command' in misc.el
 (defun evil-copy-chars-from-line (n num &optional col)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -6604,6 +6604,44 @@ if no previous selection")
       "<;; This buffer is for notes,
 ;;[ ]>and for Lisp evaluation.")))
 
+;;; Replace state
+
+(ert-deftest evil-test-replacement ()
+  "Test replacing consecutive characters"
+  :tags '(evil replace)
+  (ert-info ("Replace and restore consecutive characters")
+    (evil-test-buffer
+     ";; [T]his buffer is for notes"
+     ("Rfoo")
+     ";; foo[s] buffer is for notes"
+     ([backspace backspace backspace])
+     ";; [T]his buffer is for notes"))
+  (ert-info ("Replace and restore consecutive characters beyond eol")
+    (evil-test-buffer
+     ";; [T]his buffer is for notes"
+     ("wwwwRxxxxxxx")
+     ";; This buffer is for xxxxxxx[]"
+     ([backspace backspace backspace backspace backspace backspace backspace])
+     ";; This buffer is for [n]otes"))
+  (ert-info ("Replace from line below and restore")
+    (define-key evil-replace-state-map (kbd "C-e") 'evil-copy-from-below)
+    (evil-test-buffer
+     ";; [f]oo bar\n;; qux quux"
+     ("R\C-e\C-e\C-e")
+     ";; qux[ ]bar\n;; qux quux"
+     ([backspace backspace backspace])
+     ";; [f]oo bar\n;; qux quux")
+    (define-key evil-replace-state-map (kbd "C-e") nil))
+  (ert-info ("Replace from line above and restore")
+    (define-key evil-replace-state-map (kbd "C-y") 'evil-copy-from-above)
+    (evil-test-buffer
+     ";; foo bar\n;; [q]ux quux"
+     ("R\C-y\C-y\C-y")
+     ";; foo bar\n;; foo[ ]quux"
+     ([backspace backspace backspace])
+     ";; foo bar\n;; [q]ux quux")
+    (define-key evil-replace-state-map (kbd "C-y") nil)))
+
 ;;; Ex
 
 (ert-deftest evil-test-ex-parse ()


### PR DESCRIPTION
See #794.

Notes:

- This doesn't handle a sequence like `R C-3 i <backspace> <backspace> <backspace>` correctly.  Note how repetition of insertion works as expected (I've fixed a case of swapped arguments for this), but undoing doesn't.  While this peeves me greatly, Vim doesn't even allow specifying a prefix arg in replace state, so that's fine I guess.
- I've noticed that `C-e` in replace state runs the appropriate Emacs command, not the copying command.  To make the example from the linked issue work out of the box, `evil-replace-state-map` would need to get augmented, then the respective lines in the tests could be omitted.  I don't think that's part of the PR though...