### PR TITLE
Update evil-use-register: show "- in the minibuffer

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1899,7 +1899,7 @@ The return value is the yanked text."
   "Use REGISTER for the next command."
   :keep-visual t
   :repeat ignore
-  (interactive "<C>")
+  (interactive (list (read-char)))
   (setq evil-this-register register))
 
 (defvar evil-macro-buffer nil


### PR DESCRIPTION
problem:  pressing double quote, doesn't show anything in the minibuffer
solution: copy the single quote and backtick behaviour

I don't know what the angle brackets around the uppercase `C` in `(interactive "<C>")` do? So I'm not sure if there is any lost of functionality when the interactive command is changed. But copying and pasting to and from a register still works as expected.