### PR TITLE
:global should use last pattern if none given

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3502,6 +3502,9 @@ This is the same as :%s//~/&"
     (user-error "No pattern given"))
   (unless command
     (user-error "No command given"))
+  ;; TODO: `evil-ex-make-substitute-pattern' should be executed so
+  ;; :substitute can re-use :global's pattern depending on its `r'
+  ;; flag. This isn't supported currently but should be simple to add
   (evil-with-single-undo
     (let ((case-fold-search
            (eq (evil-ex-regex-case pattern 'smart) 'insensitive))

--- a/evil-search.el
+++ b/evil-search.el
@@ -1204,7 +1204,19 @@ This handler highlights the pattern of the current substitution."
 
 (defun evil-ex-parse-global (string)
   "Parse STRING as a global argument."
-  (evil-delimited-arguments string 2))
+  (let* ((args (evil-delimited-arguments string 2))
+         (pattern (nth 0 args))
+         (command (nth 1 args)))
+    ;; use last pattern if none given
+    (when (zerop (length pattern))
+      (setq pattern
+            (cond
+             ((and (eq evil-search-module 'evil-search) evil-ex-search-pattern)
+              (evil-ex-pattern-regex evil-ex-search-pattern))
+             ((and (eq evil-search-module 'isearch) (not (zerop (length isearch-string))))
+              isearch-string)
+             (t (user-error "No previous pattern")))))
+    (list pattern command)))
 
 (defun evil-ex-get-substitute-info (string &optional implicit-r)
   "Returns the substitution info of command line STRING.

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7510,7 +7510,7 @@ maybe we need one line more with some text\n")
 
 (ert-deftest evil-test-global ()
   "Test `evil-ex-global'."
-  :tags '(evil ex)
+  :tags '(evil ex global)
   (ert-info ("global delete")
     (evil-test-buffer
       "[n]o 1\nno 2\nno 3\nyes 4\nno 5\nno 6\nno 7\n"
@@ -7522,7 +7522,27 @@ maybe we need one line more with some text\n")
       (":g/no/s/[3-6]/x" [return])
       "no 1\nno 2\nno x\nyes 4\nno x\nno x\n[n]o 7\n"
       ("u")
-      "no 1\nno 2\nno [3]\nyes 4\nno 5\nno 6\nno 7\n")))
+     "no 1\nno 2\nno [3]\nyes 4\nno 5\nno 6\nno 7\n"))
+  (evil-select-search-module 'evil-search-module 'evil-search)
+  (ert-info ("global use last match if none given, with evil-search")
+    (evil-test-buffer
+      "[n]o 1\nno 2\nno 3\nyes 4\nno 5\nno 6\nno 7\n"
+      ("/yes" [return])
+      "no 1\nno 2\nno 3\nyes 4\nno 5\nno 6\nno 7\n"
+      (":g//d" [return])
+      "no 1\nno 2\nno 3\n[n]o 5\nno 6\nno 7\n"
+      (":v//d" [return])
+      ""))
+  (evil-select-search-module 'evil-search-module 'isearch)
+  (ert-info ("global use last match if none given, with isearch")
+    (evil-test-buffer
+     "[n]o 1\nno 2\nno 3\nisearch 4\nno 5\nno 6\nno 7\n"
+     ("/isearch" [return])
+     "no 1\nno 2\nno 3\nisearch 4\nno 5\nno 6\nno 7\n"
+     (":g//d" [return])
+     "no 1\nno 2\nno 3\n[n]o 5\nno 6\nno 7\n"
+     (":v//d" [return])
+     "")))
 
 (ert-deftest evil-test-normal ()
   "Test `evil-ex-normal'."


### PR DESCRIPTION
With this change, you can for example:
1. search for foo `/foo`
2. delete all lines with foo with `:g//d`

Without this commit, `:g//d` would delete *all* lines in the buffer since the empty `""` pattern matches on every line.

Please, let me know if the PR can be improved.