### PR TITLE
Remove view-mode (minor mode) from initial states

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -782,7 +782,6 @@ If STATE is nil, Evil is disabled in the buffer."
     Man-mode
     speedbar-mode
     undo-tree-visualizer-mode
-    view-mode
     woman-mode)
   "Modes that should come up in Motion state."
   :type  '(repeat symbol)


### PR DESCRIPTION
It doesn't make much sense to have it here because initial states apply to major modes only.  For minor modes, use a hook.

Prompted by http://emacs.stackexchange.com/a/32133/10