### PR TITLE
Add support for passing REGISTER and COUNT to :delete

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1449,6 +1449,23 @@ be joined with the previous line if and only if
                  'exclusive
                  nil)))
 
+(evil-define-operator evil-ex-delete (beg end type register count yank-handler)
+  "The Ex delete command.
+\[BEG,END]delete [REGISTER] [COUNT]"
+  (interactive "<R><d/><y>")
+  (when count
+    ;; with COUNT, :delete should go the end of the region and delete
+    ;; COUNT lines from there
+    (setq beg (save-excursion
+                (goto-char end)
+                (forward-line -1)
+                (point))
+          end (save-excursion
+                (goto-char end)
+                (point-at-bol count))
+          type 'line))
+  (evil-delete beg end type register yank-handler))
+
 (evil-define-operator evil-change
   (beg end type register yank-handler delete-func)
   "Change text from BEG to END with TYPE.

--- a/evil-common.el
+++ b/evil-common.el
@@ -2084,6 +2084,11 @@ The following special registers are supported.
 If REGISTER is an upcase character then text is appended to that
 register instead of replacing its content."
   (cond
+   ((not (characterp register))
+    (user-error "Invalid register"))
+   ;; don't allow modification of read-only registers
+   ((member register '(?: ?. ?%))
+    (user-error "Can't modify read-only register"))
    ((eq register ?\")
     (kill-new text))
    ((and (<= ?1 register) (<= register ?9))

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -450,7 +450,7 @@ included in `evil-insert-state-bindings' by default."
 (evil-ex-define-cmd "co[py]" 'evil-copy)
 (evil-ex-define-cmd "t" "copy")
 (evil-ex-define-cmd "m[ove]" 'evil-move)
-(evil-ex-define-cmd "d[elete]" 'evil-delete)
+(evil-ex-define-cmd "d[elete]" 'evil-ex-delete)
 (evil-ex-define-cmd "y[ank]" 'evil-yank)
 (evil-ex-define-cmd "go[to]" 'evil-goto-char)
 (evil-ex-define-cmd "j[oin]" 'evil-ex-join)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2066,7 +2066,7 @@ New Tex[t]
 
 (ert-deftest evil-test-delete ()
   "Test `evil-delete'"
-  :tags '(evil operator)
+  :tags '(evil operator delete)
   (ert-info ("Delete characters")
     (evil-test-buffer
       ";; This buffer is for notes you don't want to save[.]"
@@ -2111,7 +2111,35 @@ New Tex[t]
       ("d3s")
       "[T]his buffer is for notes you don't want to save.
 If you want to create a file, visit that file with C-x C-f,
-then enter the text in that file's own buffer.")))
+then enter the text in that file's own buffer."))
+  (ert-info (":delete")
+    (evil-test-buffer
+     "a\n[b]\nc\nd\n"
+     (":delete")
+     "a\nc\nd\n"))
+  (ert-info (":delete with COUNT")
+    (evil-test-buffer
+     "a\n[b]\nc\nd\n"
+     (":delete 2")
+     "a\nd\n"))
+  (ert-info (":delete with COUNT in visual state")
+    (evil-test-buffer
+     "a\n<b\nc>\nd\ne\nf\n"
+     (":delete 3")
+     "a\nb\nf\n"))
+  (ert-info (":delete with REGISTER")
+    (evil-test-buffer
+     "a\n[b]\nc\nd\n"
+     (":delete r") ;; delete into the 'r' register
+     "a\nc\nd\n"
+     ;; chech the 'r' register contains the deleted text
+     (should (string= (substring-no-properties (evil-get-register ?r)) "b\n"))))
+  (ert-info (":delete with REGISTER and COUNT")
+    (evil-test-buffer
+     "a\n[b]\nc\nd\ne\nf\n"
+     (":delete r 3")
+     "a\ne\nf\n"
+     (should (string= (substring-no-properties (evil-get-register ?r)) "b\nc\nd\n")))))
 
 (ert-deftest evil-test-delete-line ()
   "Test `evil-delete-line'"

--- a/evil-types.el
+++ b/evil-types.el
@@ -382,8 +382,7 @@ Returns a list (REGISTER COUNT)."
          (arg-count (length split-args))
          (arg0 (car split-args))
          (arg1 (cadr split-args))
-         (number-regex "^[1-9][0-9]*$")
-         (register-regex "^[a-zA-Z]$")
+         (number-regex "^-?[1-9][0-9]*$")
          (register nil)
          (count nil))
     (cond
@@ -400,13 +399,21 @@ Returns a list (REGISTER COUNT)."
      ((> arg-count 2)
       (user-error "Invalid use")))
 
-    (when (and register (not (string-match-p register-regex register)))
-      (user-error "Invalid register"))
-    (when (and count (not (string-match-p number-regex count)))
-      (user-error "Invalid count"))
+    ;; if register is given, check it's valid
+    (when register
+      (unless (= (length register) 1)
+        (user-error "Invalid register"))
+      (setq register (string-to-char register)))
 
-    (list (if register (string-to-char register) nil)
-          (if count (string-to-number count) nil))))
+    ;; if count is given, check it's valid
+    (when count
+      (unless (string-match-p number-regex count)
+        (user-error "Invalid count"))
+      (setq count (string-to-number count))
+      (unless (> count 0)
+        (user-error "Invalid count")))
+
+    (list register count)))
 
 (provide 'evil-types)
 

--- a/evil-types.el
+++ b/evil-types.el
@@ -370,6 +370,44 @@ If visual state is inactive then those values are nil."
   (when (evil-ex-p)
     (evil-ex-get-substitute-info evil-ex-argument t)))
 
+(evil-define-interactive-code "<d/>"
+  "Ex delete argument."
+  (when (evil-ex-p)
+    (evil-ex-get-delete-info evil-ex-argument)))
+
+(defun evil-ex-get-delete-info (string)
+  "Parse STRING as a :delete argument.
+Returns a list (REGISTER COUNT)."
+  (let* ((split-args (split-string (or string "")))
+         (arg-count (length split-args))
+         (arg0 (car split-args))
+         (arg1 (cadr split-args))
+         (number-regex "^[1-9][0-9]*$")
+         (register-regex "^[a-zA-Z]$")
+         (register nil)
+         (count nil))
+    (cond
+     ;; :delete REGISTER or :delete COUNT
+     ((= arg-count 1)
+      (if (string-match-p number-regex arg0)
+          (setq count arg0)
+        (setq register arg0)))
+     ;; :delete REGISTER COUNT
+     ((eq arg-count 2)
+      (setq register arg0
+            count arg1))
+     ;; more than 2 args aren't allowed
+     ((> arg-count 2)
+      (user-error "Invalid use")))
+
+    (when (and register (not (string-match-p register-regex register)))
+      (user-error "Invalid register"))
+    (when (and count (not (string-match-p number-regex count)))
+      (user-error "Invalid count"))
+
+    (list (if register (string-to-char register) nil)
+          (if count (string-to-number count) nil))))
+
 (provide 'evil-types)
 
 ;;; evil-types.el ends here


### PR DESCRIPTION
With this change, `:delete` can be called like so:
- `:d 2` to del 2 lines
- `:d x` to del the line and put the text into register `x`
- `:d x 2` to del 2 lines into register `x`

Passing COUNT while in visual mode works a bit strange in my opinion, but the behaviour should be the same as in vim.

Also, I'm not sure function `evil-ex-get-delete-info` should be in evil-types.el, but I couldn't find a better place.

As always, please let me know if the PR can be improved.

Refs #760 