### PR TITLE
Fix bounds on line by line search in evil-ex-substitute

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3404,7 +3404,10 @@ resp.  after executing the command."
                                (goto-char m)
                                (move-marker m nil))
                              (when (re-search-forward evil-ex-substitute-regex
-                                                      (line-end-position) t nil)
+                                                      (save-excursion
+                                                        (forward-line)
+                                                        (point))
+                                                      t nil)
                                (goto-char (match-beginning 0))
                                (throw 'found (match-data))))))))
                 (evil-ex-delete-hl 'evil-ex-substitute)
@@ -3417,7 +3420,10 @@ resp.  after executing the command."
               (goto-char m)
               (move-marker m nil))
             (when (re-search-forward evil-ex-substitute-regex
-                                     (line-end-position) t nil)
+                                     (save-excursion
+                                       (forward-line)
+                                       (point))
+                                      t nil)
               (setq evil-ex-substitute-nreplaced
                     (1+ evil-ex-substitute-nreplaced))
               (evil-replace-match evil-ex-substitute-replacement

--- a/evil-search.el
+++ b/evil-search.el
@@ -643,7 +643,10 @@ The following properties are supported:
                             (push ov new-ovs)
                             (when match-hook (funcall match-hook hl ov)))
                           (cond
-                           ((not (evil-ex-pattern-whole-line pattern))
+                           ((and (not (evil-ex-pattern-whole-line pattern))
+                                 (not (string-match-p "\n" (buffer-substring-no-properties
+                                                            (match-beginning 0)
+                                                            (match-end 0)))))
                             (forward-line))
                            ((= (match-beginning 0) (match-end 0))
                             (forward-char))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7037,7 +7037,17 @@ if no previous selection")
     (evil-test-buffer
       "[a]bc\niiiXiiiXiiiXiii\n"
       ("\"ayiwj:s/X/\\=@a/g" [return])
-      "abc\n[i]iiabciiiabciiiabciii\n")))
+      "abc\n[i]iiabciiiabciiiabciii\n"))
+  (ert-info ("Substitute newlines")
+    (evil-test-buffer
+      "[a]bc\ndef\nghi\n"
+      (":%s/\n/z/" [return])
+      "[a]bczdefzghiz"))
+  (ert-info ("Substitute newlines with g flag")
+    (evil-test-buffer
+      "[a]bc\ndef\nghi\n"
+      (":%s/\n/z/g" [return])
+      "[a]bczdefzghi")))
 
 (ert-deftest evil-test-ex-repeat-substitute-replacement ()
   "Test `evil-ex-substitute' with repeating of previous substitutions."


### PR DESCRIPTION
The per line bound should be the beginning of the next line in order to capture
new line chars (Note this won't allow the search to spill over into the new
line). All tests pass with this change.

See #824