### PR TITLE
Fix evil-search-next when search string is newline

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -229,6 +229,13 @@ one more than the current position."
       (set-text-properties 0 (length string) nil string)
       ;; position to search from
       (goto-char start)
+      ;; when `evil-move-beyond-eol' is nil and we're looking at a \n after a
+      ;; search, evil will move the cursor back so that we start the new search
+      ;; at a position prior to the \n that we just found.
+      (when (and (not evil-move-beyond-eol)
+                 (not (eobp))
+                 (= (char-after) ?\n))
+        (forward-char))
       (setq isearch-string string)
       (isearch-update-ring string regexp-p)
       (condition-case nil

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7225,7 +7225,18 @@ if no previous selection")
         (error search-failed "n")
         "foo foo foo\nbar [b]ar\nbaz baz baz\n"
         (error search-failed "N")
-        "foo foo foo\nbar [b]ar\nbaz baz baz\n"))))
+        "foo foo foo\nbar [b]ar\nbaz baz baz\n"))
+    (ert-info ("Test search for newline")
+      (evil-test-buffer
+        "[s]tart\nline 2\nline 3\n\n"
+        ("/\\n" [return])
+        "star[t]\nline 2\nline 3\n\n"
+        ("n")
+        "start\nline [2]\nline 3\n\n"
+        ("n")
+        "start\nline 2\nline [3]\n\n"
+        ("n")
+        "start\nline 2\nline 3\n[]\n"))))
 
 (ert-deftest evil-test-ex-search-offset ()
   "Test search offsets."


### PR DESCRIPTION
When the search string is a newline and evil-move-beyond-eol is nil, point gets
moved back an extra character after moving to the beginning of the matched
character (the newline). evil-search-next then finds that same newline again and
we get stuck.

Add regression test.

Fixes #823