### PR TITLE
Fix evil-search-next when search string is newline

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2565,14 +2565,18 @@ for `isearch-forward',\nwhich lists available keys:\n\n%s"
         (search-string (if evil-regexp-search
                            (car-safe regexp-search-ring)
                          (car-safe search-ring))))
-    (evil-search search-string isearch-forward evil-regexp-search)
-    (when (and (> (point) orig)
-               (save-excursion
-                 (evil-adjust-cursor)
-                 (= (point) orig)))
-      ;; Point won't move after first attempt and `evil-adjust-cursor' takes
-      ;; effect, so try again.
-      (evil-search search-string isearch-forward evil-regexp-search))
+    (goto-char
+     ;; Wrap in `save-excursion' so that multiple searches have no visual effect.
+     (save-excursion
+       (evil-search search-string isearch-forward evil-regexp-search)
+       (when (and (> (point) orig)
+                  (save-excursion
+                    (evil-adjust-cursor)
+                    (= (point) orig)))
+         ;; Point won't move after first attempt and `evil-adjust-cursor' takes
+         ;; effect, so start again.
+         (evil-search search-string isearch-forward evil-regexp-search))
+       (point)))
     (when (and count (> count 1))
       (dotimes (var (1- count))
         (evil-search search-string isearch-forward evil-regexp-search)))))

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2561,11 +2561,21 @@ for `isearch-forward',\nwhich lists available keys:\n\n%s"
   "Repeat the last search."
   :jump t
   :type exclusive
-  (dotimes (var (or count 1))
-    (evil-search (if evil-regexp-search
-                     (car-safe regexp-search-ring)
-                   (car-safe search-ring))
-                 isearch-forward evil-regexp-search)))
+  (let ((orig (point))
+        (search-string (if evil-regexp-search
+                           (car-safe regexp-search-ring)
+                         (car-safe search-ring))))
+    (evil-search search-string isearch-forward evil-regexp-search)
+    (when (and (> (point) orig)
+               (save-excursion
+                 (evil-adjust-cursor)
+                 (= (point) orig)))
+      ;; Point won't move after first attempt and `evil-adjust-cursor' takes
+      ;; effect, so try again.
+      (evil-search search-string isearch-forward evil-regexp-search))
+    (when (and count (> count 1))
+      (dotimes (var (1- count))
+        (evil-search search-string isearch-forward evil-regexp-search)))))
 
 (evil-define-motion evil-search-previous (count)
   "Repeat the last search in the opposite direction."

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7225,7 +7225,18 @@ if no previous selection")
         (error search-failed "n")
         "foo foo foo\nbar [b]ar\nbaz baz baz\n"
         (error search-failed "N")
-        "foo foo foo\nbar [b]ar\nbaz baz baz\n"))))
+        "foo foo foo\nbar [b]ar\nbaz baz baz\n"))
+    (ert-info ("Test search for newline")
+      (evil-test-buffer
+        "[s]tart\nline 2\nline 3\n\n"
+        ("/\\n" [return])
+        "star[t]\nline 2\nline 3\n\n"
+        ("n")
+        "start\nline [2]\nline 3\n\n"
+        ("n")
+        "start\nline 2\nline [3]\n\n"
+        ("n")
+        "start\nline 2\nline 3\n[]\n"))))
 
 (ert-deftest evil-test-ex-search-offset ()
   "Test search offsets."


### PR DESCRIPTION
When the search string is a newline and evil-move-beyond-eol is nil, point gets
moved back an extra character after moving to the beginning of the matched
character (the newline). evil-search-next then finds that same newline again and
we get stuck.

Add regression test.

Fixes #823