### PR TITLE
List view buffers kbd Q kill buffer and window

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3838,6 +3838,7 @@ should be left-aligned for left justification."
       (funcall evil-list-view-select-action (nth 1 entry)))))
 
 (define-key evil-list-view-mode-map (kbd "q") #'kill-this-buffer)
+(define-key evil-list-view-mode-map (kbd "Q") #'kill-buffer-and-window)
 (define-key evil-list-view-mode-map [follow-link] nil) ;; allows mouse-1 to be activated
 (define-key evil-list-view-mode-map [mouse-1] #'evil-list-view-goto-entry)
 (define-key evil-list-view-mode-map [return] #'evil-list-view-goto-entry)


### PR DESCRIPTION
```
problem:  evil-list-view buffers like these: evil-show-registers,
          evil-show-marks, evil-show-jumps and evil-ex-show-digraphs, leaves
          behind their window, when they are closed by pressing: q
solution: add Q as an additional key binding that calls: kill-buffer-and-window
```

The issue occurs when only one window is open and one calls `:reg`. Because the evil registers buffer opens in a new split window, and when `q` is pressed, then only the buffer gets removed, but the new split window stays open.

`q` works as expected when two or more windows were open before calling `:reg`. Because the previous window configuration gets restored when the evil register buffer is closed.

This PR makes it easier to choose if the window also should be closed.