### PR TITLE
Fix minor issue with evil-paste-from-register

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1991,7 +1991,8 @@ The return value is the yanked text."
        (delete-overlay overlay))))
   (when (evil-paste-before nil register t)
     ;; go to end of pasted text
-    (forward-char)))
+    (unless (eobp)
+      (forward-char))))
 
 (defun evil-paste-last-insertion ()
   "Paste last insertion."


### PR DESCRIPTION
With point on a word, :%s/<C-r><C-w> gives an end of buffer warning from the
forward-char at the end of evil-paste-from-register.