### PR TITLE
Prevent infinite loop in evil-ex-substitute

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3435,9 +3435,13 @@ resp.  after executing the command."
                                       (not case-replace)))
                 (setq evil-ex-substitute-last-point (point)))
               (goto-char (match-end 0))
-              (unless (or whole-line
-                          match-contains-newline)
-                (forward-line)))))
+              (cond ((and (not whole-line)
+                          (not match-contains-newline))
+                     (forward-line))
+                    ((= (match-beginning 0) (match-end 0))
+                     (if (eobp)
+                         (throw 'exit-search t)
+                       (forward-char)))))))
       (evil-ex-delete-hl 'evil-ex-substitute)
       (delete-overlay evil-ex-substitute-overlay))
 

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7123,7 +7123,12 @@ if no previous selection")
     (evil-test-buffer
       "[a]bc\naef\nahi\n"
       (":%s/a//gn" [return])
-      "[a]bc\naef\nahi\n")))
+      "[a]bc\naef\nahi\n"))
+  (ert-info ("Substitute $ does not loop infinitely")
+    (evil-test-buffer
+      "[a]bc\ndef\nghi"
+      (":%s/$/ END/g" [return])
+      "abc END\ndef END\n[g]hi END")))
 
 (ert-deftest evil-test-ex-repeat-substitute-replacement ()
   "Test `evil-ex-substitute' with repeating of previous substitutions."


### PR DESCRIPTION
Zero length regexps, particularly "$", may get matched over and over. Also add a
test for this.

Fixes #849