### PR TITLE
Add evil-kill-on-visual-paste option

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1980,7 +1980,8 @@ The return value is the yanked text."
         (if paste-eob
             (evil-paste-after count register)
           (evil-paste-before count register)))
-      (kill-new new-kill)
+      (when evil-kill-on-visual-paste
+        (kill-new new-kill))
       ;; mark the last paste as visual-paste
       (setq evil-last-paste
             (list (nth 0 evil-last-paste)

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -386,6 +386,13 @@ before point."
   :type '(repeat symbol)
   :group 'evil)
 
+(defcustom evil-kill-on-visual-paste t
+  "Whether `evil-visual-paste' adds the replaced text to the kill
+ring, making it the default for the next paste. The default, t,
+replicates the default vim behavior."
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-want-C-i-jump t
   "Whether \"C-i\" jumps forward like in Vim."
   :type 'boolean


### PR DESCRIPTION
Allows one to prevent evil-visual-paste from automatically adding the replaced
text to the kill ring, which changes what will be pasted next.

It may just be me, but I hate the default vim behavior of essentially yanking the replaced text. I don't see why you would want to replace some text with a paste and then paste the replaced text somewhere else.

This is a simple change to make in the evil source that would be difficult to accomplish with an external plugin. 