### PR TITLE
use read-key instead of read-char

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -732,7 +732,7 @@ Columns are counted from zero."
   :keep-visual t
   :repeat nil
   :type exclusive
-  (interactive (list (read-char)))
+  (interactive (list (read-key)))
   (let ((marker (evil-get-marker char)))
     (cond
      ((markerp marker)
@@ -756,7 +756,7 @@ Columns are counted from zero."
   :keep-visual t
   :repeat nil
   :type line
-  (interactive (list (read-char)))
+  (interactive (list (read-key)))
   (evil-goto-mark char noerror)
   (evil-first-non-blank))
 
@@ -2002,7 +2002,7 @@ The return value is the yanked text."
            (put-text-property 0 1 'face 'minibuffer-prompt string)
            (put-text-property 0 1 'cursor t string)
            (overlay-put overlay 'after-string string)
-           (list (or evil-this-register (read-char))))
+           (list (or evil-this-register (read-key))))
        (delete-overlay overlay))))
   (when (evil-paste-before nil register t)
     ;; go to end of pasted text
@@ -2087,7 +2087,7 @@ when called interactively."
                      (if (numberp current-prefix-arg)
                          current-prefix-arg
                        0) 1)
-           register (or evil-this-register (read-char)))
+           register (or evil-this-register (read-key)))
      (cond
       ((or (and (eq register ?@) (eq evil-last-register ?:))
            (eq register ?:))
@@ -3407,8 +3407,8 @@ resp.  after executing the command."
                     (move-overlay evil-ex-substitute-overlay
                                   (match-beginning 0)
                                   (match-end 0))
-                    (catch 'exit-read-char
-                      (while (setq response (read-char prompt))
+                    (catch 'exit-read-key
+                      (while (setq response (read-key prompt))
                         (when (member response '(?y ?a ?l))
                           (unless count-only
                             (evil-replace-match evil-ex-substitute-replacement
@@ -3423,9 +3423,9 @@ resp.  after executing the command."
                                                  (evil-ex-hl-get-max
                                                   'evil-ex-substitute)))
                         (cl-case response
-                          ((?y ?n) (throw 'exit-read-char t))
+                          ((?y ?n) (throw 'exit-read-key t))
                           (?a (setq confirm nil)
-                              (throw 'exit-read-char t))
+                              (throw 'exit-read-key t))
                           ((?q ?l ?\C-\[) (throw 'exit-search t))
                           (?\C-e (evil-scroll-line-down 1))
                           (?\C-y (evil-scroll-line-up 1))))))

--- a/evil-common.el
+++ b/evil-common.el
@@ -1900,7 +1900,7 @@ with regard to indentation."
 POS defaults to the current position of point.
 If ADVANCE is t, the marker advances when inserting text at it;
 otherwise, it stays behind."
-  (interactive (list (read-char)))
+  (interactive (list (read-key)))
   (catch 'done
     (let ((marker (evil-get-marker char t)) alist)
       (unless (markerp marker)

--- a/evil-types.el
+++ b/evil-types.el
@@ -244,7 +244,7 @@ the last column is excluded."
 
 (evil-define-interactive-code "c"
   "Read character."
-  (list (read-char)))
+  (list (read-key)))
 
 (evil-define-interactive-code "p"
   "Prefix argument converted to number."


### PR DESCRIPTION
In a terminal, read char will read only part of a multibyte unicode character, whereas read-key will get the whole thing.  Graphical emacs doesn't have this problem.  This is related to #726 and potentially #605.  So for instance when an evil operator prompts me for a character and I type `»` from my non-US/qwerty layout, it gets gibberish instead (`Â` is sent, then `\273` is sent to the buffer when I press another key).  This fixes it.