### PR TITLE
Wire up semantic and tags for "goto-definition" when available

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2683,10 +2683,13 @@ The search is unbounded, i.e., the pattern is not wrapped in
          ;; highlight the occurrence
          ((numberp ipos)
           (evil-search search t t ipos))
-         ;; imenu failed, so just go to first occurrence in buffer
-         (t
-          (evil-search search t t (point-min)))))
-       ;; no imenu, so just go to first occurrence in buffer
+         ;; imenu failed, try semantic
+         ((and (fboundp 'semantic-ia-fast-jump)
+               (ignore-errors (semantic-ia-fast-jump ipos)))
+          ()) ;; noop, already jumped
+         ((fboundp 'xref-find-definitions) ;; semantic failed, try the generic func
+          (xref-find-definitions string))))
+       ;; otherwise just go to first occurrence in buffer
        (t
         (evil-search search t t (point-min)))))))
 


### PR DESCRIPTION
Usually I am using a one year outdated evil-mode because [of a regression](https://github.com/emacs-evil/evil/issues/684), and with occasional recent update I found the vanilla evil is missing this nice little feature of using semantic and tags.

So I thought others might be happy to get this as well. I've used this code for may be a year *(cleaned up a bit though before the commit).

