### PR TITLE
Truncate temporary-goal-column which might be a floating number

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2329,7 +2329,7 @@ be passed via ARGS."
         (setq endcol (max endcol
                           (min eol-col
                                (1+ (min (1- most-positive-fixnum)
-                                        temporary-goal-column))))))
+                                        (truncate temporary-goal-column)))))))
       ;; start looping over lines
       (goto-char startpt)
       (while (< (point) endpt)


### PR DESCRIPTION
Without this fix, actions such as `d C-v 5 j` would occasionally fail
with such errors `Wrong type argument: wholenump, 6.0`