### PR TITLE
Fix evil-ex-substitute (#881)

### DIFF
--- a/evil-tests.el
+++ b/evil-tests.el
@@ -6781,7 +6781,22 @@ if no previous selection")
     (evil-test-buffer
       "[a]bc\ndef\nghi"
       (":%s/$/ END/g" [return])
-      "abc END\ndef END\n[g]hi END")))
+      "abc END\ndef END\n[g]hi END"))
+  (ert-info ("Substitute the zero-length beginning of line character")
+    (evil-test-buffer
+      "[a]bc\ndef\nghi"
+      (":s/^/ #/" [return])
+      " [#]abc\ndef\nghi"))
+  (ert-info ("Substitute the zero-length beginning of line character with g flag")
+    (evil-test-buffer
+      "[a]bc\ndef\nghi"
+      (":s/^/ #/g" [return])
+      " [#]abc\ndef\nghi"))
+  (ert-info ("Use Substitute to delete individual characters")
+    (evil-test-buffer
+      "[x]xyxxz"
+      (":%s/x//g" [return])
+      "[y]z")))
 
 (ert-deftest evil-test-ex-repeat-substitute-replacement ()
   "Test `evil-ex-substitute' with repeating of previous substitutions."


### PR DESCRIPTION
I'm beginning to not want to be responsible for this function. In dealing with the special case where `:%s/$/ TEST/` can loop infinitely because point never moves past the first "$", I think I introduced the regression in #881. With the line "xxxx" in the buffer `:s/x//` in the old version would skip over every other "x" because it accidentally identified the match as having zero length. 

It's not the prettiest piece of work, but I think I've dealt with the special cases here in a fairly robust way. I added three tests, and a bunch of comments to the code to explain. 

Please review 