### PR TITLE
fixes #884

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1363,41 +1363,48 @@ match-data reflects the last successful match (that caused COUNT
 to reach zero). The behaviour of this functions is similar to
 `up-list'."
   (let* ((count (or count 1))
-         (forwardp (> count 0))
-         (dir (if forwardp +1 -1)))
+         (dir (if (> count 0) +1 -1)))
     (catch 'done
       (while (not (zerop count))
         (let* ((pnt (point))
                (cl (save-excursion
-                     (and (re-search-forward (if forwardp end beg) nil t dir)
+                     (and (re-search-forward end nil t dir)
                           (or (/= pnt (point))
                               (progn
                                 ;; zero size match, repeat search from
                                 ;; the next position
                                 (forward-char dir)
-                                (re-search-forward (if forwardp end beg) nil t dir)))
+                                (re-search-forward end nil t dir)))
                           (point))))
                (match (match-data t))
                (op (save-excursion
-                     (and (re-search-forward (if forwardp beg end) cl t dir)
+                     (and (re-search-forward beg cl t dir)
                           (or (/= pnt (point))
                               (progn
                                 ;; zero size match, repeat search from
                                 ;; the next position
                                 (forward-char dir)
-                                (re-search-forward (if forwardp beg end) cl t dir)))
+                                (re-search-forward beg cl t dir)))
                           (point)))))
           (cond
-           ((not cl)
-            (goto-char (if forwardp (point-max) (point-min)))
+           ((and (not op) (not cl))
+            (goto-char (if (> dir 0) (point-max) (point-min)))
             (set-match-data nil)
             (throw 'done count))
-           (t
+           ((> dir 0)
+            (if cl
+                (progn
+                  (setq count (1- count))
+                  (if (zerop count) (set-match-data match))
+                  (goto-char cl))
+              (setq count (1+ count))
+              (goto-char op)))
+           ((< dir 0)
             (if op
                 (progn
-                  (setq count (if forwardp (1+ count) (1- count)))
+                  (setq count (1+ count))
                   (goto-char op))
-              (setq count (if forwardp (1- count) (1+ count)))
+              (setq count (1- count))
               (if (zerop count) (set-match-data match))
               (goto-char cl))))))
       0)))


### PR DESCRIPTION
This reverts commit a5465f3517d0b19349b35a619a3f8bc061e74d8d, which breaks ~[targets.el](http://github.com/noctuid/targets.el)~ this perfectly valid macro:

```elisp
;; modified to be able to specify name and use `function'
(defmacro define-and-bind-text-object (name key start-regex end-regex)
  (let ((inner-name (make-symbol (concat "evil-inner-" name)))
        (outer-name (make-symbol (concat "evil-a-" name))))
    `(progn
       (evil-define-text-object ,inner-name (count &optional beg end type)
         (evil-select-paren ,start-regex ,end-regex beg end type count nil))
       (evil-define-text-object ,outer-name (count &optional beg end type)
         (evil-select-paren ,start-regex ,end-regex beg end type count t))
       (define-key evil-inner-text-objects-map ,key #',inner-name)
       (define-key evil-outer-text-objects-map ,key #',outer-name))))

(define-and-bind-text-object "pipe" "|" "|" "|")
```

See #884 for discussion. 

Also see noctuid/targets.el#19 and [this](https://stackoverflow.com/questions/18102004/emacs-evil-mode-how-to-create-a-new-text-object-to-select-words-with-any-non-sp/22418983#22418983) SO answer. 

I summon @wasamasa and @willghatch. @willghatch, I'm proposing reverting this in light of the problems encountered by targets.el and the macro discussed in #884. 

