### PR TITLE
fix pipe text-object macro

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1379,7 +1379,8 @@ to reach zero). The behaviour of this functions is similar to
                           (point))))
                (match (match-data t))
                (op (save-excursion
-                     (and (re-search-forward (if forwardp beg end) cl t dir)
+                     (and (not (equal beg end))
+                          (re-search-forward (if forwardp beg end) cl t dir)
                           (or (/= pnt (point))
                               (progn
                                 ;; zero size match, repeat search from


### PR DESCRIPTION
Fixes issue #884.

The code assumed (badly) that the start and end patterns were distinct.  If the start and end patterns are the same it was looping until hitting the end of the buffer.  This fixes the balancing behavior to not try to balance delimiters that are the same on both sides.