### PR TITLE
Add evil-respect-visual-line-mode option

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2357,7 +2357,16 @@ non nil it should be number > 0. The insertion will be repeated
 in the next VCOUNT - 1 lines below the current one."
   (interactive "p")
   (push (point) buffer-undo-list)
-  (back-to-indentation)
+  (if (and evil-respect-visual-line-mode
+           visual-line-mode)
+      (let ((visual-beg (save-excursion
+                          (beginning-of-visual-line)
+                          (point)))
+            (indent (save-excursion
+                      (back-to-indentation)
+                      (point))))
+        (goto-char (max visual-beg indent)))
+    (back-to-indentation))
   (setq evil-insert-count count
         evil-insert-lines nil
         evil-insert-vcount
@@ -2374,7 +2383,10 @@ The insertion will be repeated COUNT times.  If VCOUNT is non nil
 it should be number > 0. The insertion will be repeated in the
 next VCOUNT - 1 lines below the current one."
   (interactive "p")
-  (evil-move-end-of-line)
+  (if (and evil-respect-visual-line-mode
+           visual-line-mode)
+      (end-of-visual-line)
+    (evil-move-end-of-line))
   (setq evil-insert-count count
         evil-insert-lines nil
         evil-insert-vcount

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -216,6 +216,14 @@ a line."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-respect-visual-line-mode nil
+  "Make certain evil commands respect `visual-line-mode'.
+
+Currently, this affects the behavior of `evil-insert-line' and
+`evil-append-line', or I and A in normal state."
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-repeat-find-to-skip-next t
   "Whether a repeat of t or T should skip an adjacent character."
   :type 'boolean


### PR DESCRIPTION
This option adds some initial support for adjusting the behavior of some
important commands in visual-line-mode to make them behave more intuitively.

This commit just adjusts the behavior of evil-insert-line and evil-append-line.