### PR TITLE
Add evil-respect-visual-line-mode option

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -723,8 +723,10 @@ has already been started; otherwise TARGET is called."
            (setq this-command #'digit-argument)
            (call-interactively #'digit-argument))
           (t
-           (setq this-command #',target)
-           (call-interactively #',target)))))))
+           (let ((target (or (command-remapping #',target)
+                             #',target)))
+             (setq this-command target)
+             (call-interactively target))))))))
 
 (defun evil-extract-append (file-or-append)
   "Return an (APPEND . FILENAME) pair based on FILE-OR-APPEND.

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -553,6 +553,16 @@ Based on `evil-enclose-ace-jump-for-motion'."
      (add-to-list 'evil-motion-state-modes 'ag-mode)
      (evil-add-hjkl-bindings ag-mode-map 'motion)))
 
+;; visual-line-mode integration
+(when evil-respect-visual-line-mode
+  (let ((swaps '((evil-next-line . evil-next-visual-line)
+                 (evil-previous-line . evil-previous-visual-line)
+                 (evil-beginning-of-line . evil-beginning-of-visual-line)
+                 (evil-end-of-line . evil-end-of-visual-line))))
+    (dolist (swap swaps)
+      (define-key visual-line-mode-map (vector 'remap (car swap)) (cdr swap))
+      (define-key visual-line-mode-map (vector 'remap (cdr swap)) (car swap)))))
+
 (provide 'evil-integration)
 
 ;;; abbrev.el

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -216,6 +216,18 @@ a line."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-respect-visual-line-mode nil
+  "Whether to remap movement commands when `visual-line-mode' is active.
+This variable must be set before evil is loaded. The commands
+swapped are
+
+`evil-next-line'         <-> `evil-next-visual-line'
+`evil-previous-line'     <-> `evil-previous-visual-line'
+`evil-beginning-of-line' <-> `evil-beginning-of-visual-line'
+`evil-end-of-line'       <-> `evil-end-of-visual-line'"
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-repeat-find-to-skip-next t
   "Whether a repeat of t or T should skip an adjacent character."
   :type 'boolean


### PR DESCRIPTION
Supersedes #901 

Remap commands to use visual version when `visual-line-mode` is active.
These commands are swapped

```
evil-next-line         <-> evil-next-visual-line
evil-previous-line     <-> evil-previous-visual-line
evil-beginning-of-line <-> evil-beginning-of-visual-line
evil-end-of-line       <-> evil-end-of-visual-line
```

**Note**: I previously thought reworking yy, dd, pp, and so on was worth it here, but I changed my mind. I don't think the behavior is that intuitive (at least how I did it), and I think using specific motions like d$ are a better choice. 