### PR TITLE
Get evil initial state from parent modes [updated]

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -313,7 +313,7 @@ initial state for a mode can be set with
 `evil-set-initial-state'."
   (let (state modes)
     (catch 'done
-      (dolist (entry (nreverse (evil-state-property t :modes)) default)
+      (dolist (entry (evil-state-property t :modes) default)
         (setq state (car entry)
               modes (symbol-value (cdr entry)))
         (when (or (memq mode modes)

--- a/evil-core.el
+++ b/evil-core.el
@@ -293,16 +293,18 @@ Returns a different symbol if FUN is an alias, otherwise FUN."
         symbol-function
       fun)))
 
-(defun evil--derived-mode-p (mode modes)
+(defun evil--get-parents (mode)
+  "Returns the parents of the MODE in a bottom-up list,
+including (and starting with) the mode itself."
   (let ((parent (evil--real-function mode))
-	visited-modes)
-    (while (and parent (not (memq parent modes)))
-      (push parent visited-modes)	; remember already visited parents
-      (setq parent			; get the next parent
+	modes)
+    (while parent
+      (push parent modes)
+      (setq parent
 	    (evil--real-function (get parent 'derived-mode-parent)))
-      (when (memq parent visited-modes)
-	(error "Circular list detected. Aborting.")))
-    parent))
+      (when (memq parent modes)
+	(error "Circular parent list detected. Aborting.")))
+    (nreverse modes)))
 
 (defun evil-initial-state (mode &optional default noinherit)
   "Return the Evil state to use for MODE.
@@ -311,14 +313,17 @@ MODE, or any of its parents. If NOINHERIT is not nil, returns
 DEFAULT if no initial state is associated with this mode. The
 initial state for a mode can be set with
 `evil-set-initial-state'."
-  (let (state modes)
+  (let ((parents (if noinherit
+		     (list mode)
+		   (evil--get-parents mode)))
+	state modes)
     (catch 'done
-      (dolist (entry (evil-state-property t :modes) default)
-        (setq state (car entry)
-              modes (symbol-value (cdr entry)))
-        (when (or (memq mode modes)
-                  (and (not noinherit) (evil--derived-mode-p mode modes)))
-          (throw 'done state))))))
+      (dolist (parent parents default)
+	(dolist (entry (evil-state-property t :modes))
+	  (setq state (car entry)
+		modes (symbol-value (cdr entry)))
+	  (when (memq parent modes)
+	    (throw 'done state)))))))
 
 (defun evil-set-initial-state (mode state)
   "Set the initial state for MODE to STATE.

--- a/evil-core.el
+++ b/evil-core.el
@@ -316,10 +316,11 @@ initial state for a mode can be set with
   (let ((parents (if noinherit
 		     (list mode)
 		   (evil--get-parents mode)))
+	(modes-states (evil-state-property t :modes))
 	state modes)
     (catch 'done
       (dolist (parent parents default)
-	(dolist (entry (evil-state-property t :modes))
+	(dolist (entry modes-states)
 	  (setq state (car entry)
 		modes (symbol-value (cdr entry)))
 	  (when (memq parent modes)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8180,6 +8180,43 @@ maybe we need one line more with some text\n")
      ("ci|testing" [escape])
      "| foo |testing| bar |")))
 
+;;; Core
+
+(ert-deftest evil-test-initial-state ()
+  "Test `evil-initial-state'"
+  :tags '(evil core)
+  (ert-info ("Check default state")
+    (should (eq (evil-initial-state 'prog-mode 'normal) 'normal)))
+  (ert-info ("Basic functionality")
+    (evil-set-initial-state 'prog-mode 'insert)
+    (should (eq (evil-initial-state 'prog-mode) 'insert)))
+  (ert-info ("Inherit initial state from a parent")
+    (require 'cc-mode)
+    (should (eq (evil-initial-state 'c-mode) 'insert)))
+  (ert-info ("Do not inherit initial state, if so specified")
+    (should (eq (evil-initial-state 'c-mode 'emacs t)
+                'emacs)))
+  (ert-info ("Check for inheritance loops")
+    (put 'prog-mode 'derived-mode-parent 'c-mode)
+    (should (eq (unwind-protect
+                   (condition-case nil
+                       (evil-initial-state 'c-mode) ; raise error
+                     (error                         ; catch error
+                      nil))
+                 (put 'prog-mode 'derived-mode-parent nil))
+            nil)))
+  (ert-info ("Don't check for inheritance loops")
+    (put 'prog-mode 'derived-mode-parent 'c-mode)
+    (should (eq (unwind-protect
+                   (condition-case nil
+                       (evil-initial-state 'c-mode 'emacs t)
+                     (error
+                      nil))
+                 (put 'prog-mode 'derived-mode-parent nil))
+            'emacs)))
+  ;; restore normality, other tests seem to rely on this
+  (evil-set-initial-state 'prog-mode 'normal))
+
 (provide 'evil-tests)
 
 ;;; evil-tests.el ends here


### PR DESCRIPTION
This is basically a modification of the solution proposed by @wasamasa (described in #775 and also discussed in #497) which allows `evil-initial-state` to decide the initial state for buffers based not only on the state set for the current mode (e.g. using `evil-set-initial-state`), but also on those of its parent modes. 

I added a check for unusual situations in the parent -> derived modes relationship (see [Malabarba/paradox#86](https://github.com/Malabarba/paradox/issues/86)), in which a derived mode is set also as a parent of its parent; in such situations, `evil-initial-state` will now raise an error (avoiding the endless loop from the original solution). Another proposed [approach](https://github.com/emacs-evil/evil/issues/497#issuecomment-322514176) was that of using a counter that bails out with an error if the visit from a parent to its parent (and so on) goes above a limit, but I think the current solution is the best because it checks for the actual problem.

I also added an extra optional parameter (`noinherit`) for `evil-initial-state`, allowing for an initial state check that does not consider the parents of the mode, just the mode itself (i.e. in this case, `evil-initial-state` works exactly as before this patch).