### PR TITLE
Fix term-mode undo issue

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -221,7 +221,7 @@ some buffer, but only if `global-undo-tree-mode' is also
 activated."
        (when (and (boundp 'global-undo-tree-mode)
                   global-undo-tree-mode)
-         (undo-tree-mode 1)))
+         (turn-on-undo-tree-mode)))
 
      (add-hook 'evil-local-mode-hook #'evil-turn-on-undo-tree-mode)
 


### PR DESCRIPTION
Currently Evil breaks `term-char-mode` undo by enabling `undo-tree-mode`, see
https://github.com/syl20bnr/spacemacs/issues/4063#issuecomment-162913414

`turn-on-undo-tree-mode` checks the variable `undo-tree-incompatible-major-modes`
before enabling `undo-tree-mode`, see https://github.com/emacs-evil/evil/blob/master/lib/undo-tree.el#L2618