### PR TITLE
Fix register `#'

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2041,7 +2041,7 @@ The following special registers are supported.
                                          evil-ex-current-buffer))
                   (user-error "No file name")))
              ((= register ?#)
-              (or (with-current-buffer (other-buffer) (buffer-file-name))
+              (or (buffer-file-name (window-buffer (next-window)))
                   (user-error "No file name")))
              ((eq register ?/)
               (or (car-safe


### PR DESCRIPTION
Because the `other-buffer` function returns the most recently selected buffer which it not necessarily the buffer being displayed in the "next window".
Therefore, we should use `(window-buffer (next-window))` instead.