### PR TITLE
evil-commands.el: Add a configurable list of evil-change commands

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -308,7 +308,7 @@ If point is at the end of the buffer and cannot be moved signal
       (evil-forward-beginning thing count))
      ;; the evil-change operator, maybe behave like ce or cE
      ((and evil-want-change-word-to-end
-           (eq evil-this-operator #'evil-change)
+           (memq evil-this-operator evil-change-commands)
            (< orig (or (cdr-safe (bounds-of-thing-at-point thing)) orig)))
       ;; forward-thing moves point to the correct position because
       ;; this is an exclusive motion

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1280,6 +1280,11 @@ having higher priority.")
 (defvar evil-command-properties nil
   "Specifications made by `evil-define-command'.")
 
+(defvar evil-change-commands '(evil-change)
+  "Commands that wrap or replace `evil-change'.
+This list exists to apply an inconsistency with vim's change command
+to commands that wrap or redefine it. See emacs-evil/evil#916.")
+
 (defvar evil-transient-vars '(cua-mode transient-mark-mode select-active-regions)
   "List of variables pertaining to Transient Mark mode.")
 


### PR DESCRIPTION
This patch adds a new variable, `evil-change-commands`, which defines
functions that evil will treat as bound to 'c'. When wrapping
`evil-change`, add your function to this list to get the same behavior
as `evil-change`.

Let me know if anyone spots anything wrong, or if you think this can be improved.

Also, thanks so much for maintaining evil, it's a huge part of my life :smile:

Closes #916
