### PR TITLE
Add a dir-locals file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+;; Don't use tabs for el files
+((emacs-lisp-mode .
+   ((indent-tabs-mode . nil))))


### PR DESCRIPTION
This PR adds a trivial dir-locals file which overrides `indent-tabs-mode` to nil in emacs-lisp files.

Let me know if you think anything else should be added (fill-column, indention level, etc).