### PR TITLE
Fixed evil-yank-line-handler and evil-yank-block-handler when yank-excluded-properties is t

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2478,8 +2478,10 @@ The tracked insertion is set to `evil-last-insertion'."
   "Inserts the current text linewise."
   (let ((text (apply #'concat (make-list (or evil-paste-count 1) text)))
         (opoint (point)))
-    (remove-list-of-text-properties
-     0 (length text) yank-excluded-properties text)
+    (if (eq yank-excluded-properties t)
+        (set-text-properties 0 (length text) nil text)
+      (remove-list-of-text-properties 0 (length text)
+                                      yank-excluded-properties text))
     (cond
      ((eq this-command 'evil-paste-before)
       (evil-move-beginning-of-line)

--- a/evil-common.el
+++ b/evil-common.el
@@ -2474,14 +2474,18 @@ The tracked insertion is set to `evil-last-insertion'."
       (unless (eq register ?_)
         (kill-new text)))))
 
+(defun evil-remove-yank-excluded-properties (text)
+  "Removes `yank-excluded-properties' from text."
+  (if (eq yank-excluded-properties t)
+      (set-text-properties 0 (length text) nil text)
+    (remove-list-of-text-properties 0 (length text)
+                                    yank-excluded-properties text)))
+
 (defun evil-yank-line-handler (text)
   "Inserts the current text linewise."
   (let ((text (apply #'concat (make-list (or evil-paste-count 1) text)))
         (opoint (point)))
-    (if (eq yank-excluded-properties t)
-        (set-text-properties 0 (length text) nil text)
-      (remove-list-of-text-properties 0 (length text)
-                                      yank-excluded-properties text))
+    (evil-remove-yank-excluded-properties text)
     (cond
      ((eq this-command 'evil-paste-before)
       (evil-move-beginning-of-line)
@@ -2548,8 +2552,7 @@ The tracked insertion is set to `evil-last-insertion'."
               (move-to-column (+ col begextra) t)
             (move-to-column col t)
             (insert (make-string begextra ?\s)))
-          (remove-list-of-text-properties 0 (length text)
-                                          yank-excluded-properties text)
+          (evil-remove-yank-excluded-properties text)
           (insert text)
           (unless (eolp)
             ;; text follows, so we have to insert spaces

--- a/evil-common.el
+++ b/evil-common.el
@@ -2475,7 +2475,7 @@ The tracked insertion is set to `evil-last-insertion'."
         (kill-new text)))))
 
 (defun evil-remove-yank-excluded-properties (text)
-  "Removes `yank-excluded-properties' from text."
+  "Removes `yank-excluded-properties' from TEXT."
   (if (eq yank-excluded-properties t)
       (set-text-properties 0 (length text) nil text)
     (remove-list-of-text-properties 0 (length text)


### PR DESCRIPTION
Some major modes in emacs have variable yank-excluded-properites as t that means to discard all text properties when yanking. With the old evil-yank-line-handler function this case is not correctly implemented, only discards text properties when yank-excluded-properties is a list. With the old function there is a bug that with web-mode and evil-mode activated in a buffer, when you yank whole line with `yy` and then paste the yanked line, if you copy a piece of text of the yanked line and paste it, the pasted text appears in a new line and truncated. With this commit this bug is fixed.
