### PR TITLE
Allow user to control whether v$ takes newline

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -174,7 +174,7 @@ If COUNT is given, move COUNT - 1 lines downward first."
   (when evil-track-eol
     (setq temporary-goal-column most-positive-fixnum
           this-command 'next-line))
-  (unless (evil-visual-state-p)
+  (unless (and  (evil-visual-state-p) evil-v$-gets-eol)
     (evil-adjust-cursor)
     (when (eolp)
       ;; prevent "c$" and "d$" from deleting blank lines

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -216,6 +216,11 @@ a line."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-v$-gets-eol t
+  "Whether when v$ is performed, the new line character is taken as well"
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-respect-visual-line-mode nil
   "Whether to remap movement commands when `visual-line-mode' is active.
 This variable must be set before evil is loaded. The commands


### PR DESCRIPTION
The default is set so that existing behavior is unaffected. It is true that the existing behavior is consistent with vim, but vim's behavior here is quite self inconsistent. If you do `d$` or `D`, or `y$` or `Y`, you don't grab the newline. But if you do `v$`, you do. So `v$d` is different from `d$`, which is weird. This is also very annoying when using surround, as wanting to surround something to the end of the line via `v$S)` is very common.