### PR TITLE
If an autoload, load ex function so completion can be provided

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -458,6 +458,13 @@ in case of incomplete or unknown commands."
 (defun evil-ex-argument-completion-at-point ()
   (let ((context (evil-ex-syntactic-context (1- (point)))))
     (when (memq 'argument context)
+      ;; if it's an autoload, load the function; this allows external
+      ;; packages to register autoloaded ex commands which will be
+      ;; loaded when ex argument completion is triggerred
+      (let ((binding-definition (symbol-function (evil-ex-binding evil-ex-cmd))))
+        (when (autoloadp binding-definition)
+          (autoload-do-load binding-definition)))
+
       (let* ((beg (or (and evil-ex-argument
                            (get-text-property 0 'ex-index evil-ex-argument))
                       (point)))


### PR DESCRIPTION
With this PR evil's ex completion will load an autoloaded function before providing completion.

For example, the following scenario will work:
1. external package [evil-expat](https://github.com/edkolev/evil-expat) will define ex command `:rename NEW-NAME` (which moves/renames the current file and its buffer) with an autoload cookie like  so:
```emacs-lisp

(evil-define-command evil-expat-rename (bang new-name)
  "Rename the current file and its buffer to NEW-NAME..."
  (interactive "<!><f>")
  ...)

;;;###autoload
(eval-after-load 'evil
  '(progn
     (evil-ex-define-cmd "rename" 'evil-expat-rename)
     (autoload 'evil-expat-rename "evil-expat" nil t)))
```
2. the evil-expat-autoloads.el file is loaded by `(package-initialize)`
3. when the user enters `:rename /tm<TAB>` the evil-expat package will be loaded and the prompt will be completed to `:rename /tmp/`

Without this PR, entering `:rename /tm<TAB>` would result to `:rename /tm`, without completing `/tm` to `/tmp`.

Please let me know if the PR can be improved.

I've previously mentioned autoloading of ex commands in #926 but then I didn't know enough about autoloading to have meaning discussion.
