### PR TITLE
Extended docstring for evil-find-char.

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -645,7 +645,8 @@ and jump to the corresponding one."
   (backward-char))
 
 (evil-define-motion evil-find-char (count char)
-  "Move to the next COUNT'th occurrence of CHAR."
+  "Move to the next COUNT'th occurrence of CHAR.
+Movement is restricted to the current line unless `evil-cross-lines' is non-nil."
   :type inclusive
   (interactive "<c><C>")
   (setq count (or count 1))


### PR DESCRIPTION
Documented the dependency from 'evil-cross-lines' custom variable.