### PR TITLE
CI: use "emacs-travis" instead of EVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,23 @@
 language: generic
 sudo: false
 
+env:
+  global:
+    - CURL="curl -fsSkL --retry 9 --retry-delay 9"
+  matrix:
+  - EMACS_VERSION=24.3
+  - EMACS_VERSION=24.4
+  - EMACS_VERSION=24.5
+  - EMACS_VERSION=25.1
+  - EMACS_VERSION=25.2
+  - EMACS_VERSION=master
+
+matrix:
+  allow_failures:
+    - env: EMACS_VERSION=master
+    # Emacs 25.1 segfaults when running make test
+    - env: EMACS_VERSION=25.1
+
 # NOTE: flyspell test
 addons:
   apt:
@@ -8,25 +25,11 @@ addons:
       - aspell
       - aspell-en
 
-before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
-  - evm install $EVM_EMACS --use --skip
-  - cask --debug
-
-env:
-  matrix:
-    - EVM_EMACS=emacs-24.3-travis
-    - EVM_EMACS=emacs-24.4-travis
-    - EVM_EMACS=emacs-24.5-travis
-    - EVM_EMACS=emacs-25.1-travis
-    - EVM_EMACS=emacs-git-snapshot-travis
-
-# FIXME: Emacs 25.1 segfaults when running make test.
-matrix:
-  allow_failures:
-    - env: EVM_EMACS=emacs-25.1-travis
-    - env: EVM_EMACS=emacs-git-snapshot-travis
+install:
+  - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
+  - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
+  - export EMACS=/tmp/emacs/bin/emacs
 
 script:
-  - emacs --version
-  - make test
+  - $EMACS --version
+  - emacs=$EMACS make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh
-EMACS = emacs
+EMACS ?= emacs
 FILES = $(filter-out evil-test-helpers.el evil-tests.el evil-pkg.el,$(wildcard evil*.el))
 VERSION := $(shell sed -ne '/define-package/,$$p' evil-pkg.el | sed -ne '/^\s*"[[:digit:]]\+\(\.[[:digit:]]\+\)*"\s*$$/ s/^.*"\(.*\)".*$$/\1/p')
 ELPAPKG = evil-$(VERSION)


### PR DESCRIPTION
This PR is an attempt to fix the CI segfaults that we've been dealing with.

The main change is that EVM (and its binaries) is not used. Instead, the emacs binaries from this repo are used https://github.com/npostavs/emacs-travis

These are the same binaries used by magit since this PR https://github.com/npostavs/emacs-travis/releases
For reference, here's magit's .travis.yml https://github.com/magit/magit/blob/master/.travis.yml

I'm not sure if the segfault-ing will be completely fixed, however, I've had about 10 successful successive CI runs here
https://github.com/edkolev/evil/commits/ci-experiment

Some notes:
- the CI jobs run for roughly the same time, ~1 min
- this PR adds a check for emacs 25.2 and emacs "master"
- emacs 25.1 is still in the "allow_faulires" group - I've seen it fail with this CI setup; I think it failed 3 times out of the 10 runs


