### PR TITLE
Decode mouse control sequences

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4202,7 +4202,7 @@ DO-MOUSE-DRAG-REGION-POST-PROCESS should only be used by
     ;; Track the mouse until we get a non-movement event.
     (track-mouse
       (while (progn
-               (setq event (read-event))
+               (setq event (read-key))
                (or (mouse-movement-p event)
                    (memq (car-safe event) '(switch-frame select-window))))
         (unless (evil-visual-state-p)


### PR DESCRIPTION
`xterm-mouse-mode' uses control sequences for mouse events which need to be
decoded, otherwise each character in the sequence will be executed as a command.

Fixes #960.

This change came about from [Emacs Bug#29150](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=29150).