### PR TITLE
Fix detection of newlines in evil-ex-substitute

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3439,7 +3439,11 @@ resp.  after executing the command."
                                         (not case-replace)))
                   (setq evil-ex-substitute-last-point (point)))
                 (goto-char match-end)
-                (cond ((and (not whole-line)
+                (cond ((>= (point) end-marker)
+                       ;; Don't want to perform multiple replacements at the end
+                       ;; of the search region.
+                       (throw 'exit-search t))
+                      ((and (not whole-line)
                             (not match-contains-newline))
                        (forward-line)
                        ;; forward-line just moves to the end of the line on the
@@ -3459,7 +3463,7 @@ resp.  after executing the command."
                                   evil-ex-substitute-regex end-marker t)
                                  (= pnt (point))))))
                        (if (or (eobp)
-                               (= (point) end-marker))
+                               (>= (point) end-marker))
                            (throw 'exit-search t)
                          (forward-char))))))))
       (evil-ex-delete-hl 'evil-ex-substitute)

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3388,7 +3388,9 @@ resp.  after executing the command."
                     (match-end (move-marker (make-marker) (match-end 0)))
                     (match-data (match-data)))
                 (goto-char match-beg)
-                (setq match-contains-newline (string-match-p "\n" match-str))
+                (setq match-contains-newline
+                      (string-match-p "\n" (buffer-substring-no-properties
+                                            match-beg match-end)))
                 (setq zero-length-match (= match-beg match-end))
                 (when (and (string= "^" evil-ex-substitute-regex)
                            (= (point) end-marker))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -6767,6 +6767,11 @@ if no previous selection")
       "[a]bc\ndef\nghi\n"
       (":%s/\n/z/g" [return])
       "[a]bczdefzghiz"))
+  (ert-info ("Substitute newlines without newline in regexp")
+    (evil-test-buffer
+      "[A]BC\nDEF\nGHI\n"
+      (":%s/[^]]*/z/" [return])
+      "Z"))
   (ert-info ("Substitute n flag does not replace")
     (evil-test-buffer
       "[a]bc\naef\nahi\n"


### PR DESCRIPTION
This addresses part of the problem in #969. I'll look at the rest later. 