### PR TITLE
Always create new auxiliary map in evil-define-key*

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -1011,7 +1011,7 @@ its behavior more predictable."
                     ((eq keymap 'local)
                      (evil-state-property st :local-keymap t))
                     (t
-                     (evil-get-auxiliary-keymap keymap st t))))
+                     (evil-get-auxiliary-keymap keymap st t t))))
             (if (listp state) state (list state))))))
     (while key
       (dolist (map aux-maps)


### PR DESCRIPTION
If the parent keymap already has an auxiliary keymap, ignore it. For example, if the user attempted to bind a key in emacs-lisp-mode-map before this commit, evil-define-key* could define the key in the corresponding auxiliary keymap in lisp-shared-mode-map instead of creating a new auxiliary keymap in emacs-lisp-mode-map. This resulted in keys bound in emacs-lisp-mode-map with evil-define-key potentially being bound in other keymaps that inherit from lisp-shared-mode-map (e.g.
lisp-mode-map).

Addresses #709.