### PR TITLE
Add evil-use-derived-mode-state

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -283,6 +283,11 @@ See also `evil-initial-state'."
               (when (setq mode (evil-initial-state mode))
                 (throw 'done mode)))))
         (evil-initial-state major-mode)
+        ;; see `help-fns--parent-mode'
+        (when (and evil-use-derived-mode-state
+                   (symbolp major-mode)
+                   (get major-mode 'derived-mode-parent))
+          (evil-initial-state (get major-mode 'derived-mode-parent)))
         default)))
 
 (defun evil-initial-state (mode &optional default)

--- a/evil-core.el
+++ b/evil-core.el
@@ -283,11 +283,19 @@ See also `evil-initial-state'."
               (when (setq mode (evil-initial-state mode))
                 (throw 'done mode)))))
         (evil-initial-state major-mode)
-        ;; see `help-fns--parent-mode'
-        (when (and evil-use-derived-mode-state
-                   (symbolp major-mode)
-                   (get major-mode 'derived-mode-parent))
-          (evil-initial-state (get major-mode 'derived-mode-parent)))
+        ;; similar to `derived-mode-p'
+        (when evil-use-derived-mode-state
+          (let ((mode major-mode)
+                (checked-modes (list major-mode))
+                state)
+            (while (and (not state)
+                        (symbolp mode)
+                        (setq mode (get mode 'derived-mode-parent))
+                        ;; in case there's a cycle
+                        (not (memq mode checked-modes)))
+              (push mode checked-modes)
+              (setq state (evil-initial-state mode)))
+            state))
         default)))
 
 (defun evil-initial-state (mode &optional default)

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -605,6 +605,21 @@ in `evil-emacs-state-modes', `evil-insert-state-modes' or
   :type  'symbol
   :group 'evil)
 
+(defcustom evil-use-derived-mode-state nil
+  "Whether to consider parent modes when deciding on initial state.
+When non-nil, if the current major mode does not have an initial
+state set for it using `evil-set-initial-state', but its parent
+mode does, then use the initial state from the parent mode. For
+example,
+
+  (setq evil-use-derived-mode-state t)
+  (evil-set-initial-state 'special-mode 'motion)
+
+makes motion state the default for all modes derived from
+`special-mode'."
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-buffer-regexps
   '(("^ \\*load\\*" . nil))
   "Regular expression determining the initial state for a buffer.


### PR DESCRIPTION
This variable allows evil-initial-state-for-buffer to use the initial state of a
parent mode if one is not found for the current major mode. For example,

(setq evil-use-derived-mode-state t)
(evil-set-initial-state 'special-mode 'motion)

makes motion state the default for all modes derived from special mode.