### PR TITLE
Rework #984

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -282,42 +282,42 @@ See also `evil-initial-state'."
             (when (and (boundp mode) (symbol-value mode))
               (when (setq mode (evil-initial-state mode))
                 (throw 'done mode)))))
-        (evil-initial-state major-mode)
-        ;; Check parent modes. Similar to `derived-mode-p'
-        (catch 'state
-          (let ((mode major-mode)
-                checked-modes)
-            (while (and mode (symbolp mode))
-              (when (memq mode checked-modes)
-                (error "Circular reference detected in ancestors of %s\n%s"
-                       major-mode checked-modes)
-                (throw 'state nil))
-              (let ((state (evil-initial-state mode)))
-                (when state
-                  (throw 'state state)))
-              (push mode checked-modes)
-              (setq mode (get mode 'derived-mode-parent)))
-            nil))
+        (evil-initial-state major-mode nil t)
         default)))
 
-(defun evil-initial-state (mode &optional default)
+(defun evil-initial-state (mode &optional default follow-parent checked-modes)
   "Return the Evil state to use for MODE or its alias.
 Returns DEFAULT if no initial state is associated with MODE.
 The initial state for a mode can be set with
-`evil-set-initial-state'."
-  (when mode
+`evil-set-initial-state'.
+
+If FOLLOW-PARENT is non-nil, also check parent modes of MODE and
+its alias. CHECKED-MODES is used internally and should not be set
+initially."
+  (cond
+   ((and mode (symbolp mode) (memq mode checked-modes))
+    (error "Circular reference detected in ancestors of %s\n%s"
+           major-mode checked-modes))
+   ((and mode (symbolp mode))
     (let ((mode-alias (let ((func (symbol-function mode)))
                         (when (symbolp func)
                           func)))
           state modes)
-      (catch 'done
-        (dolist (entry (evil-state-property t :modes) default)
-          (setq state (car entry)
-                modes (symbol-value (cdr entry)))
-          (when (or (memq mode modes)
-                    (and mode-alias
-                         (memq mode-alias modes)))
-            (throw 'done state)))))))
+      (or
+       (catch 'done
+         (dolist (entry (evil-state-property t :modes) default)
+           (setq state (car entry)
+                 modes (symbol-value (cdr entry)))
+           (when (or (memq mode modes)
+                     (and mode-alias
+                          (memq mode-alias modes)))
+             (throw 'done state))))
+       (when follow-parent
+         (evil-initial-state (get mode 'derived-mode-parent)
+                             nil t (cons mode checked-modes)))
+       (when follow-parent
+         (evil-initial-state (get mode-alias 'derived-mode-parent)
+                             nil t (cons mode-alias checked-modes))))))))
 
 (defun evil-set-initial-state (mode state)
   "Set the initial state for MODE to STATE.

--- a/evil-core.el
+++ b/evil-core.el
@@ -289,8 +289,8 @@ See also `evil-initial-state'."
                 checked-modes)
             (while (and mode (symbolp mode))
               (when (memq mode checked-modes)
-                (message "Circular reference detected in ancestors of %s\n%s"
-                         major-mode checked-modes)
+                (error "Circular reference detected in ancestors of %s\n%s"
+                       major-mode checked-modes)
                 (throw 'state nil))
               (let ((state (evil-initial-state mode)))
                 (when state

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8257,6 +8257,48 @@ when an error stops the execution of the macro"
       ; should not raise an "Selecting deleted buffer" error
       (evil-visual-update-x-selection buf))))
 
+;;; Core
+
+(ert-deftest evil-test-initial-state ()
+  "Test `evil-initial-state'"
+  :tags '(evil core)
+  (define-derived-mode test-1-mode prog-mode "Test1")
+  (define-derived-mode test-2-mode test-1-mode "Test2")
+  (evil-set-initial-state 'test-1-mode 'insert)
+  (ert-info ("Check default state")
+    (should (eq (evil-initial-state 'prog-mode 'normal) 'normal)))
+  (ert-info ("Basic functionality 1")
+    (should (eq (evil-initial-state 'test-1-mode) 'insert)))
+  (ert-info ("Basic functionality 2")
+    (evil-test-buffer
+      "abc\ndef\n"
+      (test-1-mode)
+      (should (eq evil-state 'insert))))
+  (ert-info ("Inherit initial state from a parent")
+    (evil-test-buffer
+      "abc\ndef\n"
+      (test-2-mode)
+      (should (eq evil-state 'insert))))
+  (evil-set-initial-state 'test-1-mode nil)
+  (ert-info ("Check for inheritance loops")
+    (evil-test-buffer
+      "abc\ndef\n"
+      (unwind-protect
+          (let ((major-mode 'test-2-mode))
+            (put 'test-1-mode 'derived-mode-parent 'test-2-mode)
+            ;; avoid triggering all of the hooks here, some of which might get
+            ;; caught in loops depending on the environment. settings major-mode
+            ;; is sufficient for `evil-initial-state-for-buffer' to work.
+            (should-error (evil-initial-state-for-buffer)))
+        (put 'test-1-mode 'derived-mode-parent 'prog-mode))))
+  (defalias 'test-1-alias-mode 'test-1-mode)
+  (define-derived-mode test-3-mode test-1-alias-mode "Test3")
+  (evil-set-initial-state 'test-1-mode 'insert)
+  (ert-info ("Check inheritance from major mode aliases")
+    "abc\ndef\n"
+    (test-3-mode)
+    (should (eq evil-state 'insert))))
+
 (provide 'evil-tests)
 
 ;;; evil-tests.el ends here


### PR DESCRIPTION
@wasamasa Here's a different version of #984. Changes are

  1. I removed the customization variable. I think this is sufficiently correct functionality to make it the default even if it does modify someone's config slightly. 

  2. I now teach `evil-initial-state` to look at aliases for modes. This makes a little more sense to me and simplifies the code. 

  3. I detect the circular references and print a message as requested. 
Teach evil-initial-state to look at aliases for a mode when they exist and to
handle nil for modes

Note that I still need to add tests for this. 