### PR TITLE
Optionally load evil-integration.el

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ compile: $(ELCFILES)
 	@echo Compute dependencies
 	@rm -f .depend
 	@for f in $(FILES); do \
-	    sed -n "s/(require '\(evil-.*\))/$${f}c: \1.elc/p" $$f >> .depend;\
+	    sed -n "s/ *(require '\(evil-[^)]*\).*)/$${f}c: \1.elc/p" $$f >> .depend;\
 	done
 
 -include .depend

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1853,6 +1853,12 @@ Otherwise the previous command is assumed as substitute.")
           "1.2.13"))))
   "The current version of Evil")
 
+(defcustom evil-want-integration t
+  "Whether to load evil-integration.el.
+This variable must be set before evil is loaded."
+  :type 'boolean
+  :group 'evil)
+
 (defun evil-version ()
   (interactive)
   (message "Evil version %s" evil-version))

--- a/evil.el
+++ b/evil.el
@@ -139,10 +139,7 @@
 (require 'evil-maps)
 
 (when evil-want-integration
-;; TODO creating the .depend file breaks if the following require is
-;; not on a line of its own
-(require 'evil-integration)
-)
+  (require 'evil-integration))
 
 (run-hooks 'evil-after-load-hook)
 

--- a/evil.el
+++ b/evil.el
@@ -137,7 +137,12 @@
 (require 'evil-commands)
 (require 'evil-jumps)
 (require 'evil-maps)
+
+(when evil-want-integration
+;; TODO creating the .depend file breaks if the following require is
+;; not on a line of its own
 (require 'evil-integration)
+)
 
 (run-hooks 'evil-after-load-hook)
 


### PR DESCRIPTION
This is a WIP PR as a result of #992 

I haven't self-tested thoroughly yet. Plus, there's an issue with the generation of `.depend` which is currently worked-around like so:

```elisp
(when evil-want-integration
;; TODO creating the .depend file breaks if the following require is
;; not on a line of its own
(require 'evil-integration)
)
```

Edit: the workaround is is now removed.

Any suggestions for improvements are welcome.