### PR TITLE
Add evil-define-key-with-key-func

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -1077,34 +1077,46 @@ its behavior more predictable."
 
 (defmacro evil-define-key-with-key-func (key-func state keymap &rest bindings)
   "Call `evil-define-key' using KEY-FUNC on each key in BINDINGS.
-KEY-FUNC should be an unquoted form acting on the unbound symbol
-key (i.e., this is an anaphoric macro). The simplest and most
-useful example is
+KEY-FUNC can take one of two forms. It can be an unquoted
+function that takes a string and returns a valid key
+description. It can also be an unquoted form involving the
+unbound symbol key. For example, the following three statements
+are equivalent.
 
-\(evil-define-key-with-key-func (kbd key) STATE KEYMAP BINDINGS)
+\(evil-define-key-with-key-func (kbd key) 'normal key-map
+  \"C-f\" 'foo
+  \"C-b\" 'bar)
 
-which translates into a call to `evil-define-key' after applying
-`kbd' to each key in BINDINGS. As with `evil-define-key',
-BINDINGS is assumed to be an alternating list of keys and their
-associated bindings. The arguments STATE and KEYMAP have the same
-meaning as they do in `evil-define-key'.
+\(evil-define-key-with-key-func kbd 'normal key-map
+  \"C-f\" 'foo
+  \"C-b\" 'bar)
+
+\(evil-define-key 'normal key-map
+  (kbd \"C-f\") 'foo
+  (kbd \"C-b\") 'bar)
+
+The first two translate into calls to `evil-define-key' after
+applying `kbd' to each key in BINDINGS. As with
+`evil-define-key', BINDINGS is assumed to be an alternating list
+of keys and their associated bindings. The arguments STATE and
+KEYMAP have the same meaning as they do in `evil-define-key'.
 
 If KEY-FUNC is nil there is no meaningful difference between this
 macro and `evil-define-key'."
   (declare (indent defun))
-  (let* ((is-key t)
-         (key-func (or key-func 'key))
-         (transformed-bindings
-          (mapcar (lambda (bnd)
-                    (if is-key
-                        (progn
-                          (setq is-key nil)
-                          `((lambda (key) ,key-func) ,bnd))
-                      (setq is-key t)
-                      bnd))
-                  bindings)))
+  (let ((key-func (cond ((functionp key-func)
+                         key-func)
+                        (key-func
+                         `(lambda (key) ,key-func))
+                        (t
+                         'identity))))
     `(evil-define-key ,state ,keymap
-       ,@transformed-bindings)))
+       ,@(let ((is-key t))
+           (mapcar (lambda (bnd)
+                     (prog1
+                         (if is-key (funcall key-func bnd) bnd)
+                       (setq is-key (not is-key))))
+                   bindings)))))
 
 (defun evil-define-minor-mode-key (state mode key def &rest bindings)
   "Similar to `evil-define-key' but the bindings are associated


### PR DESCRIPTION
This is just an idea I had for simplifying key bindings...

This is an anaphoric version of evil-define-key which allows one to transform
all of the key descriptions according to a "key-func". A useful example is

(evil-define-key-with-key-func (kbd key) STATE KEYMAP BINDINGS)

which expands to a standard evil-define-key call after applying kbd to every key
in BINDINGS. More info is in the docstring.