### PR TITLE
Fix loading of advice for find-tag-noselect

### DIFF
--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -290,8 +290,9 @@ POS defaults to point."
 (defadvice split-window-internal (before evil-jumps activate)
   (evil-set-jump))
 
-(defadvice find-tag-noselect (before evil-jumps activate)
-  (evil-set-jump))
+(eval-after-load 'etags
+  '(defadvice find-tag-noselect (before evil-jumps activate)
+     (evil-set-jump)))
 
 (if (bound-and-true-p savehist-loaded)
     (evil--jumps-savehist-load)


### PR DESCRIPTION
Defer advice until after etags has loaded to prevent a find-tag-noselect was
redefined message.