### PR TITLE
Switch to VM-based CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-sudo: false
+sudo: true
 
 env:
   global:
@@ -15,15 +15,10 @@ env:
 matrix:
   allow_failures:
     - env: EMACS_VERSION=master
-    # Emacs 25.1 segfaults when running make test
-    - env: EMACS_VERSION=25.1
 
-# NOTE: flyspell test
-addons:
-  apt:
-    packages:
-      - aspell
-      - aspell-en
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y aspell aspell-en # required for flyspell test
 
 install:
   - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ env:
     - CURL="curl -fsSkL --retry 9 --retry-delay 9"
   matrix:
   - EMACS_VERSION=24.3
-  - EMACS_VERSION=24.4
   - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.1
-  - EMACS_VERSION=25.2
+  - EMACS_VERSION=25.3
   - EMACS_VERSION=master
 
 matrix:


### PR DESCRIPTION
I've experimented with two CI branches today, in the first one I built the Emacsen from source, the second one happened after I realized all of those segfault started happening after I opted out of VMs when implementing flyspell-related tests. So, I switched back to VMs and this seems to have made a great difference, no segfault so far.  I also took the liberty of reducing the number of builds, the rationale here being that most of them included only minor changes, so the latest one with many changes was chosen.