### PR TITLE
If `evil-ex` is called with initial input, call `evil-ex-update`

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -181,7 +181,7 @@ is appended to the line."
         evil-ex-info-string
         result)
     (minibuffer-with-setup-hook
-        #'evil-ex-setup
+        (if initial-input #'evil-ex-setup-and-update #'evil-ex-setup)
       (setq result
             (read-from-minibuffer
              ":"
@@ -238,6 +238,11 @@ interactive actions during ex state."
         '(evil-ex-command-completion-at-point
           evil-ex-argument-completion-at-point)))
 (put 'evil-ex-setup 'permanent-local-hook t)
+
+(defun evil-ex-setup-and-update ()
+  "Initialize Ex minibuffer with `evil-ex-setup', then call `evil-ex-update'."
+  (evil-ex-setup)
+  (evil-ex-update))
 
 (defun evil-ex-teardown ()
   "Deinitialize Ex minibuffer.


### PR DESCRIPTION
This PR tries to fix the following issue - calling `evil-ex` non-interactively with initial input `%s/.../...` doesn't show the substitution overlays.

To reproduce the issue I'm trying to fix:
- enter the following in the scratch buffer:
```elisp
;; hello this world
(evil-ex "%s/this/that/")
```
- execute the second line

Without this PR, the substitute overlays aren't displayed -- you don't see what will be replaced.