### PR TITLE
Reveal hidden search terms in evil-ex-substitute

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -33,6 +33,7 @@
 (require 'evil-jumps)
 (require 'flyspell)
 (require 'cl-lib)
+(require 'reveal)
 
 ;;; Motions
 
@@ -3396,7 +3397,7 @@ reveal.el. OPEN-SPOTS is a local version of `reveal-open-spots'."
          (evil-ex-substitute-hl (evil-ex-make-hl 'evil-ex-substitute))
          (orig-point-marker (move-marker (make-marker) (point)))
          (end-marker (move-marker (make-marker) end))
-         (use-reveal (and confirm (require 'reveal nil t)))
+         (use-reveal confirm)
          reveal-open-spots
          zero-length-match
          match-contains-newline


### PR DESCRIPTION
Do this by simulating the effect of turning on reveal-mode when the substitution
requires confirmation.

Fixes #983