### PR TITLE
Don't move point following ex-substitute search

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3402,6 +3402,7 @@ resp.  after executing the command."
                     ;; beginning of this last line will be matched which we don't
                     ;; want, so we abort here.
                     (throw 'exit-search t))
+                  (setq evil-ex-substitute-last-point match-beg)
                   (if confirm
                       (let ((prompt
                              (format "Replace %s with %s (y/n/a/q/l/^E/^Y)? "
@@ -3418,7 +3419,6 @@ resp.  after executing the command."
                                 (set-match-data match-data)
                                 (evil-replace-match evil-ex-substitute-replacement
                                                     (not case-replace)))
-                              (setq evil-ex-substitute-last-point (point))
                               (setq evil-ex-substitute-nreplaced
                                     (1+ evil-ex-substitute-nreplaced))
                               (evil-ex-hl-set-region 'evil-ex-substitute
@@ -3439,8 +3439,7 @@ resp.  after executing the command."
                     (unless count-only
                       (set-match-data match-data)
                       (evil-replace-match evil-ex-substitute-replacement
-                                          (not case-replace)))
-                    (setq evil-ex-substitute-last-point (point)))
+                                          (not case-replace))))
                   (goto-char match-end)
                   (cond ((>= (point) end-marker)
                          ;; Don't want to perform multiple replacements at the end


### PR DESCRIPTION
The current behavior isn't consistent with vim (at least in my tests). It's also
annoying to have point jump to weird locations following an aborted search.

For example, with
`:%s/a/b/c`

If you abort the search with `C-g` before making replacements, point jumps to the
beginning of the region which is the beginning of the buffer in this case. This
is odd, because nothing happened but you lose your place in the buffer.