### PR TITLE
Allow auxiliary maps to be intercept maps

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -476,11 +476,15 @@ higher precedence. See also `evil-make-intercept-map'."
       (define-key copy key (or state 'all))
       (define-key keymap key copy))))
 
-(defun evil-make-intercept-map (keymap &optional state)
+(defun evil-make-intercept-map (keymap &optional state aux)
   "Give KEYMAP precedence over all Evil keymaps in STATE.
-If STATE is nil, give it precedence over all states.
-See also `evil-make-overriding-map'."
-  (let ((key [intercept-state]))
+If STATE is nil, give it precedence over all states. If AUX is non-nil, make the
+auxiliary keymap corresponding to KEYMAP in STATE an intercept keymap instead of
+KEYMAP itself. See also `evil-make-overriding-map'."
+  (let ((key [intercept-state])
+        (keymap (if aux
+                    (evil-get-auxiliary-keymap keymap state t t)
+                  keymap)))
     (define-key keymap key (or state 'all))))
 
 (defmacro evil-define-keymap (keymap doc &rest body)
@@ -810,7 +814,9 @@ See also `evil-mode-for-keymap'."
   (let* ((state (or state evil-state))
          result)
     (dolist (map (current-active-maps))
-      (when (setq map (evil-intercept-keymap-p map state))
+      (when (setq map (or (evil-intercept-keymap-p map state)
+                          (evil-intercept-keymap-p
+                           (evil-get-auxiliary-keymap map state) state)))
         (push (cons (evil-mode-for-keymap map t) map) result)))
     (setq result (nreverse result))
     result))


### PR DESCRIPTION
An example use case of making an evil keymap an intercept keymap is to allow a user to reliably give keybindings precedence over any evil keybindings made with `evil-define-key` or `evil-define-minor-mode-key` (e.g. the user uses a non-conventional prefix key that a lot of packages bind by default). Currently, doing this with intercept maps is fairly convoluted. With this commit, it would possible to just do something like this:
```
(define-minor-mode my-intercept-mode ...)
....
(evil-define-key 'normal my-intercept-mode-map
  [intercept-state] 'normal
  "<high precedence key>" #'binding)
```
