### PR TITLE
Don't use make-temp-name

### DIFF
--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -385,8 +385,7 @@ is executed at the end."
 
 (defun evil-temp-filename ()
   "Return an appropriate temporary filename."
-  (make-temp-name (expand-file-name "evil-test"
-                                    temporary-file-directory)))
+  (make-temp-file "evil-test"))
 
 (defmacro evil-with-temp-file (file-var content &rest body)
   "Create a temp file with CONTENT and bind its name to FILE-VAR within BODY.

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -383,10 +383,6 @@ is executed at the end."
        (goto-char (overlay-end ,overlay))
        (evil-test-text (or ,end-string ,string) nil nil ,after-predicate))))
 
-(defun evil-temp-filename ()
-  "Return an appropriate temporary filename."
-  (make-temp-file "evil-test"))
-
 (defmacro evil-with-temp-file (file-var content &rest body)
   "Create a temp file with CONTENT and bind its name to FILE-VAR within BODY.
 FILE-VAR must be a symbol which contains the name of the
@@ -398,7 +394,7 @@ while the temporary file exists. The temporary file is deleted at
 the end of the execution of BODY."
   (declare (indent 2)
            (debug (symbolp form body)))
-  `(let ((,file-var (evil-temp-filename)))
+  `(let ((,file-var (make-temp-file "evil-test")))
      (with-temp-file ,file-var
        ,(if (stringp content)
             `(insert ,content)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7444,22 +7444,27 @@ maybe we need one line more with some text\n")
         "line1\nline2\nline3\nline4\nline5\n"
         (":w")
         (file filename "line1\nline2\nline3\nline4\nline5\n"))))
-  (let ((filename (evil-temp-filename)))
-    (ert-info ("Write current buffer to new file")
+  (ert-info ("Write current buffer to new file")
+    (let ((filename (evil-temp-filename)))
       (evil-test-buffer
         "[l]ine1\nline2\nline3\nline4\nline5\n"
+        (delete-file filename)
         ((vconcat ":w " filename [return]))
         (file filename "line1\nline2\nline3\nline4\nline5\n")
-        (delete-file filename)))
-    (ert-info ("Write part of a buffer")
+        (delete-file filename))))
+  (ert-info ("Write part of a buffer")
+    (let ((filename (evil-temp-filename)))
       (evil-test-buffer
         "[l]ine1\nline2\nline3\nline4\nline5\n"
+        (delete-file filename)
         ((vconcat ":2,3w " filename [return]))
         (file filename "line2\nline3\n")
-        (delete-file filename)))
-    (ert-info ("Appending a file")
+        (delete-file filename))))
+  (ert-info ("Appending a file")
+    (let ((filename (evil-temp-filename)))
       (evil-test-buffer
         "[l]ine1\nline2\nline3\nline4\nline5\n"
+        (delete-file filename)
         ((vconcat ":4w " filename [return]))
         (file filename "line4\n")
         ((vconcat ":1,2w >>" filename [return]))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7445,7 +7445,7 @@ maybe we need one line more with some text\n")
         (":w")
         (file filename "line1\nline2\nline3\nline4\nline5\n"))))
   (ert-info ("Write current buffer to new file")
-    (let ((filename (evil-temp-filename)))
+    (let ((filename (make-temp-file "evil-test-write")))
       (evil-test-buffer
         "[l]ine1\nline2\nline3\nline4\nline5\n"
         (delete-file filename)
@@ -7453,7 +7453,7 @@ maybe we need one line more with some text\n")
         (file filename "line1\nline2\nline3\nline4\nline5\n")
         (delete-file filename))))
   (ert-info ("Write part of a buffer")
-    (let ((filename (evil-temp-filename)))
+    (let ((filename (make-temp-file "evil-test-write")))
       (evil-test-buffer
         "[l]ine1\nline2\nline3\nline4\nline5\n"
         (delete-file filename)
@@ -7461,7 +7461,7 @@ maybe we need one line more with some text\n")
         (file filename "line2\nline3\n")
         (delete-file filename))))
   (ert-info ("Appending a file")
-    (let ((filename (evil-temp-filename)))
+    (let ((filename (make-temp-file "evil-test-write")))
       (evil-test-buffer
         "[l]ine1\nline2\nline3\nline4\nline5\n"
         (delete-file filename)


### PR DESCRIPTION
The docstring says there is a race condition if you use `make-temp-name` then
later try to write the file which is exactly what was happening in
`evil-test-write`. I suspect this is the cause of the (random) segfaults in
travis.

Also disentangle the tests in `evil-test-write`.

@wasamasa I looked through old builds and most seemed to be failing around this test, so I think this is the issue with the seg faults. Not to mention that trying to illegally access a file (for whatever reason) along with a race condition fits with random seg faults. 