### PR TITLE
Copy text to PRIMARY, not CLIPBOARD in visual mode

### DIFF
--- a/evil-states.el
+++ b/evil-states.el
@@ -350,17 +350,13 @@ otherwise exit Visual state."
 
 (defun evil-visual-update-x-selection (&optional buffer)
   "Update the X selection with the current visual region."
-  (let ((buf (or buffer (current-buffer))))
-    (when (buffer-live-p buf)
-      (with-current-buffer buf
-        (when (and (evil-visual-state-p)
-                   (fboundp 'x-select-text)
-                   (or (not (boundp 'ns-initialized))
-                       (with-no-warnings ns-initialized))
-                   (not (eq evil-visual-selection 'block)))
-          (x-select-text (buffer-substring-no-properties
-                          evil-visual-beginning
-                          evil-visual-end)))))))
+  (with-current-buffer (or buffer (current-buffer))
+    (when (and (evil-visual-state-p)
+               (display-selections-p)
+               (not (eq evil-visual-selection 'block)))
+      (evil-set-selection 'PRIMARY (buffer-substring-no-properties
+                                    evil-visual-beginning
+                                    evil-visual-end)))))
 
 (defun evil-visual-activate-hook (&optional command)
   "Enable Visual state if the region is activated."

--- a/evil-states.el
+++ b/evil-states.el
@@ -350,13 +350,15 @@ otherwise exit Visual state."
 
 (defun evil-visual-update-x-selection (&optional buffer)
   "Update the X selection with the current visual region."
-  (with-current-buffer (or buffer (current-buffer))
-    (when (and (evil-visual-state-p)
-               (display-selections-p)
-               (not (eq evil-visual-selection 'block)))
-      (evil-set-selection 'PRIMARY (buffer-substring-no-properties
-                                    evil-visual-beginning
-                                    evil-visual-end)))))
+  (let ((buf (or buffer (current-buffer))))
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (when (and (evil-visual-state-p)
+                   (display-selections-p)
+                   (not (eq evil-visual-selection 'block)))
+          (evil-set-selection 'PRIMARY (buffer-substring-no-properties
+                                        evil-visual-beginning
+                                        evil-visual-end)))))))
 
 (defun evil-visual-activate-hook (&optional command)
   "Enable Visual state if the region is activated."

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8246,6 +8246,17 @@ when an error stops the execution of the macro"
  	 ("uu")
  	 "line 1\n[l]ine 2\nline 3")))
 
+(ert-deftest evil-test-visual-update-x-selection ()
+  "Test `evil-visual-update-x-selection'."
+  :tags '(evil)
+  (ert-info ("Buffer argument isn't a live buffer")
+    ; create buffer in normal mode, so we don't try to actually copy anything to
+    ; the X selection.
+    (let ((buf (evil-test-buffer-from-string "foobar")))
+      (kill-buffer buf)
+      ; should not raise an "Selecting deleted buffer" error
+      (evil-visual-update-x-selection buf))))
+
 (provide 'evil-tests)
 
 ;;; evil-tests.el ends here


### PR DESCRIPTION
Previously, the selected text in visual mode was copied to the X
CLIPBOARD, while 'normal' Emacs copies the active region to the
PRIMARY selection (controlled by `select-active-regions`). The latter
is also what the major X toolkits do by default.

This changes evil-visual-update-x-selection to use the PRIMARY
selection and also...

- Uses the wrapper `evil-set-selection` instead of the obsolete
  `x-select-text`
- Tests for `display-selections-p` instead of boundness of
  `x-select-text` or `ns-initialized`