### PR TITLE
Add notmuch-tree-mode to evil-emacs-state-modes

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -700,6 +700,7 @@ If STATE is nil, Evil is disabled in the buffer."
     notmuch-hello-mode
     notmuch-search-mode
     notmuch-show-mode
+    notmuch-tree-mode
     occur-mode
     org-agenda-mode
     package-menu-mode


### PR DESCRIPTION
I assume notmuch-tree-mode was introduced some while after https://github.com/emacs-evil/evil/commit/bb2999c12d67d88e254b43c03827c8e8252a391c (i.e. 7 years ago), which was when the other notmuch modes were added to evil-emacs-state-modes.