### PR TITLE
Add C-u command binding to evil-scroll-up

### DIFF
--- a/evil-maps.el
+++ b/evil-maps.el
@@ -245,6 +245,7 @@
 (define-key evil-motion-state-map "\C-]" 'evil-jump-to-tag)
 (define-key evil-motion-state-map (kbd "C-b") 'evil-scroll-page-up)
 (define-key evil-motion-state-map (kbd "C-d") 'evil-scroll-down)
+(define-key evil-motion-state-map (kbd "C-u") 'evil-scroll-up)
 (define-key evil-motion-state-map (kbd "C-e") 'evil-scroll-line-down)
 (define-key evil-motion-state-map (kbd "C-f") 'evil-scroll-page-down)
 (define-key evil-motion-state-map (kbd "C-o") 'evil-jump-backward)


### PR DESCRIPTION
This pull requests adds the mapping from c-u to evil-scroll-up.

Somehow, this mapping was missing, although the mapping for c-d was present.