### PR TITLE
evil-ex-global: parse COMMAND only once, not on each matching line

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3599,6 +3599,9 @@ This is the same as :%s//~/&"
   (evil-with-single-undo
     (let ((case-fold-search
            (eq (evil-ex-regex-case pattern 'smart) 'insensitive))
+          (command-form (evil-ex-parse command))
+          (transient-mark-mode transient-mark-mode)
+          (deactivate-mark deactivate-mark)
           match markers)
       (when (and pattern command)
         (setq isearch-string pattern)
@@ -3618,7 +3621,7 @@ This is the same as :%s//~/&"
         (unwind-protect
             (dolist (marker markers)
               (goto-char marker)
-              (evil-ex-eval command))
+              (eval command-form))
           ;; ensure that all markers are deleted afterwards,
           ;; even in the event of failure
           (dolist (marker markers)

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -826,14 +826,8 @@ Returns the line number of the match."
 NUMBER defaults to 1."
   (funcall sign (or number 1)))
 
-(defun evil-ex-eval (string &optional start)
-  "Evaluate STRING as an Ex command.
-START is the start symbol, which defaults to `expression'."
-  ;; disable the mark before executing, otherwise the visual region
-  ;; may be used as operator range instead of the ex-range
-  (let ((form (evil-ex-parse string nil start))
-        transient-mark-mode deactivate-mark)
-    (eval form)))
+;; function `evil-ex-eval' has been superseded by `evil-ex-parse' plus `eval'
+(make-obsolete 'evil-ex-eval 'evil-ex-parse "1.2.14")
 
 (defun evil-ex-parse (string &optional syntax start)
   "Parse STRING as an Ex expression and return an evaluation tree.


### PR DESCRIPTION
This PR tries to speed up the `:global` ex command. The speedup is roughly 3 times, although I haven't done extensive performance testing.

I've tested `:g/fake/d` on a file with 1k and a file with 10k lines, each line with text `fake`. The results, collected with `elp-instrument-function` on a laptop, are (in seconds):

```
before optimization:
    1k lines:  evil-ex-global       3.469728
    10k lines: evil-ex-global       34.234797

after optimization:
  1k lines:  evil-ex-global     1.6581169999
  10k lines: evil-ex-global     11.175745
```