### PR TITLE
Treat going to marks jumps

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -732,6 +732,7 @@ Columns are counted from zero."
   :keep-visual t
   :repeat nil
   :type exclusive
+  :jump t
   (interactive (list (read-char)))
   (let ((marker (evil-get-marker char)))
     (cond
@@ -756,6 +757,7 @@ Columns are counted from zero."
   :keep-visual t
   :repeat nil
   :type line
+  :jump t
   (interactive (list (read-char)))
   (evil-goto-mark char noerror)
   (evil-first-non-blank))


### PR DESCRIPTION
This PR fixes the following scenario:

- `make emacs`
- enter in a fresh buffer
```
111
222
333
```
- go to first line
- set mark with `mm`
- using `j`, go to last line
- jump to the `m` mark with
```
`m
```
- you're on the first line now
- hit `C-o` - point should jump back to 3rd line, but it doesn't

As always, please let me know if the PR can be improved.