### PR TITLE
Respect use-hard-newlines in evil-insert-newline-{above/below}

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1886,7 +1886,7 @@ closer if MOVE is non-nil."
 with regard to indentation."
   (evil-narrow-to-field
     (evil-move-beginning-of-line)
-    (insert "\n")
+    (newline)
     (forward-line -1)
     (back-to-indentation)))
 
@@ -1895,7 +1895,7 @@ with regard to indentation."
 with regard to indentation."
   (evil-narrow-to-field
     (evil-move-end-of-line)
-    (insert "\n")
+    (newline)
     (back-to-indentation)))
 
 ;;; Markers

--- a/evil-common.el
+++ b/evil-common.el
@@ -1886,7 +1886,7 @@ closer if MOVE is non-nil."
 with regard to indentation."
   (evil-narrow-to-field
     (evil-move-beginning-of-line)
-    (newline)
+    (insert (if use-hard-newlines hard-newline "\n"))
     (forward-line -1)
     (back-to-indentation)))
 
@@ -1895,7 +1895,7 @@ with regard to indentation."
 with regard to indentation."
   (evil-narrow-to-field
     (evil-move-end-of-line)
-    (newline)
+    (insert (if use-hard-newlines hard-newline "\n"))
     (back-to-indentation)))
 
 ;;; Markers


### PR DESCRIPTION
Call `newline`, which respects use-hard-newlines.

This is a (naive initial attempt at a) fix for #1026.