### PR TITLE
Bugfix 1038 handle vector macros

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1878,7 +1878,7 @@ The return value is the yanked text."
                 (insert-for-yank text))
             ;; no yank-handler, default
             (when (vectorp text)
-              (setq text (evil-vector-to-string text)))
+              (setq text (edmacro-format-keys text)))
             (set-text-properties 0 (length text) nil text)
             (push-mark opoint t)
             (dotimes (i (or count 1))
@@ -1924,7 +1924,7 @@ The return value is the yanked text."
                 (insert-for-yank text))
             ;; no yank-handler, default
             (when (vectorp text)
-              (setq text (evil-vector-to-string text)))
+              (setq text (edmacro-format-keys text)))
             (set-text-properties 0 (length text) nil text)
             (unless (eolp) (forward-char))
             (push-mark (point) t)
@@ -3083,10 +3083,13 @@ If ARG is nil this function calls `recompile', otherwise it calls
     :entries
     (cl-loop for (key . val) in (evil-register-list)
              collect `(nil [,(char-to-string key)
-                            ,(or (and val
-                                      (stringp val)
-                                      (replace-regexp-in-string "\n" "^J" val))
-                                 "")]))))
+                            ,(cond
+                              ((stringp val)
+                               (replace-regexp-in-string "\n" "^J" val))
+                              ((vectorp val)
+                               (edmacro-format-keys val))
+                              ((not val)
+                               ""))]))))
 
 (evil-define-command evil-show-marks (mrks)
   "Shows all marks.

--- a/evil-common.el
+++ b/evil-common.el
@@ -284,14 +284,10 @@ sorting in between."
                                   (list var `(pop ,sorted)))
                               vars))))))
 
-(defun evil-vector-to-string (vector)
-  "Turns vector into a string, changing <escape> to '\\e'"
-  (mapconcat (lambda (c)
-               (if (equal c 'escape)
-                   "\e"
-                 (make-string 1 c)))
-             vector
-             ""))
+(define-obsolete-function-alias
+  'evil-vector-to-string
+  'edmacro-format-keys
+  "1.2.14")
 
 ;;; Command properties
 

--- a/evil-common.el
+++ b/evil-common.el
@@ -60,7 +60,7 @@ no arguments.  In Emacs 23.2 and newer, it takes one argument."
   (called-interactively-p 'any))
 (make-obsolete 'evil-called-interactively-p
                "please use (called-interactively-p 'any) instead."
-               "Git commit 222b791")
+               "1.2.14")
 
 ;; macro helper
 (eval-and-compile

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -592,7 +592,8 @@ argument handler that requires shell completion."
 
 (define-obsolete-function-alias
   'evil-ex-shell-command-completion-at-point
-  'comint-completion-at-point)
+  'comint-completion-at-point
+  "1.2.14")
 
 (evil-ex-define-argument-type shell
   "Shell argument type, supports completion."


### PR DESCRIPTION
This includes a somewhat related change I'm not 100% sure about. When deprecating versions, shall we use the upcoming stable version? It can't be the current stable version because it already happened and doesn't include the deprecation. The next one will, however we'd either have to declare the next version number in advance or if we change our mind (like, when making a minor version instead of patch version bump) change all deprecation version numbers.

The actual fix uses the same function as the keyboard macro editor for representing a vector. I'm not 100% happy with the representation, but it's better than having it fail for the user.  I've left the string mogrification alone for now which currently replaces `\n` with `^J`, we could achieve a similar effect to Vim by replacing `\n` with `\r`, but I'm not sure whether we can rely that it will be printed as control character.