### PR TITLE
Better protect against modes that disable undo

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3435,7 +3435,8 @@ are included. The step is terminated with `evil-end-undo-step'."
 (defun evil-end-undo-step (&optional continue)
   "End a undo step started with `evil-start-undo-step'.
 Adds an undo boundary unless CONTINUE is specified."
-  (when (and evil-undo-list-pointer
+  (when (and (listp buffer-undo-list)
+             evil-undo-list-pointer
              (not evil-in-single-undo))
     (evil-refresh-undo-step)
     (unless (or continue (null (car-safe buffer-undo-list)))


### PR DESCRIPTION
Even though `evil-start-undo-step` does check `buffer-undo-list`, it is
possible that the forms wrapped by `evil-with-undo` disable undo in
the meantime. In those conditions, `evil-refresh-undo-step` will
eventually error.

https://github.com/joaotavora/sly/issues/156 references such an
incident.

* evil-common.el (evil-end-undo-step): Also check that
buffer-undo-list is a list here.