### PR TITLE
Evil window selection should trigger ElDoc.

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4159,6 +4159,10 @@ and redisplays the current buffer there."
             (select-window newwin)))))
     (balance-windows)))
 
+(with-eval-after-load 'eldoc
+  (when (fboundp 'eldoc-add-command-completions)
+    (eldoc-add-command-completions "evil-window-")))
+
 ;;; Mouse handling
 
 ;; Large parts of this code are taken from mouse.el which is

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4159,10 +4159,6 @@ and redisplays the current buffer there."
             (select-window newwin)))))
     (balance-windows)))
 
-(eval-after-load 'eldoc
-  '(when (fboundp 'eldoc-add-command-completions)
-     (eldoc-add-command-completions "evil-window-")))
-
 ;;; Mouse handling
 
 ;; Large parts of this code are taken from mouse.el which is

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4159,9 +4159,9 @@ and redisplays the current buffer there."
             (select-window newwin)))))
     (balance-windows)))
 
-(with-eval-after-load 'eldoc
-  (when (fboundp 'eldoc-add-command-completions)
-    (eldoc-add-command-completions "evil-window-")))
+(eval-after-load 'eldoc
+  '(when (fboundp 'eldoc-add-command-completions)
+     (eldoc-add-command-completions "evil-window-")))
 
 ;;; Mouse handling
 

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -578,6 +578,11 @@ Based on `evil-enclose-ace-jump-for-motion'."
   (eval-after-load 'abbrev
     '(add-hook 'evil-insert-state-exit-hook 'expand-abbrev)))
 
+;;; ElDoc
+(eval-after-load 'eldoc
+  '(when (fboundp 'eldoc-add-command-completions)
+     (eldoc-add-command-completions "evil-window-")))
+
 (provide 'evil-integration)
 
 ;;; evil-integration.el ends here


### PR DESCRIPTION
In `evil-define-motion`, especially [this line](https://github.com/emacs-evil/evil/blob/c53f8cac4897a360bc19fa4b49b556ab39c4cfee/evil-macros.el#L146), it will bind the command being defined to `eldoc-add-command` so that when this command is triggered, ElDoc will be triggered to redisplay documentation as well.

But the window selection commands (such as `evil-window-up`) are not "motion" and will not trigger ElDoc. So it's slightly annoying: after I switch to another window, and the cursor is now on top of something interesting, it will not show ElDoc documentation unless I move my cursor a bit.

This PR makes sure that window selection will trigger ElDoc message as well.