### PR TITLE
Evil macro is recorded as kmacro in same time properly.

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2046,7 +2046,7 @@ will be opened instead."
    ((and evil-this-macro defining-kbd-macro)
     (setq evil-macro-buffer nil)
     (condition-case nil
-        (end-kbd-macro)
+        (kmacro-end-macro nil)
       (error nil))
     (when last-kbd-macro
       (when (member last-kbd-macro '("" []))
@@ -2065,7 +2065,7 @@ will be opened instead."
     (when defining-kbd-macro (end-kbd-macro))
     (setq evil-this-macro register)
     (evil-set-register evil-this-macro nil)
-    (start-kbd-macro nil)
+    (kmacro-start-macro nil)
     (setq evil-macro-buffer (current-buffer)))
    (t (error "Invalid register"))))
 


### PR DESCRIPTION
This commit has to do with #1051 and my comment there.

Currently once we record evil macro, we cannot edit it properly. Meanwhile evil macro is record as kmacro in same time but only the last evil macro remains in kmacro view ring.

This commit make evil macro properly recorded as kmacro in same time so that we can change previous evil macro at least using kmacro view ring.(`kmacro-cycle-ring-previous` and `kmacro-edit-macro` and finally use it with `kmacro-call-macro`)

There is only minor change and I found no harm so far.  Passed ert test too. However any other approach and opinion are welcome. 

Thanks for this great package.