### PR TITLE
Fix evil-set-cursor when spec is a function

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -766,7 +766,8 @@ filename."
 SPECS may be a cursor type as per `cursor-type', a color
 string as passed to `set-cursor-color', a zero-argument
 function for changing the cursor, or a list of the above."
-  (unless (and (listp specs)
+  (unless (and (not (functionp specs))
+               (listp specs)
                (null (cdr-safe (last specs))))
     (setq specs (list specs)))
   (dolist (spec specs)


### PR DESCRIPTION
Docstring says that the spec can be a zero-argument function, but
evil-set-cursor incorrectly handles such a function like a list preventing the
function from being executed.