### PR TITLE
Fix bound of wrapped search in evil-search-function

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -191,10 +191,10 @@ of the buffer."
            result)
        (setq result (funcall search-fun string bound
                              ,(if wrap t 'noerror) count))
-       (when (and ,wrap (null result))
+       (when (and ,wrap (null result) (> start 1))
          (goto-char ,(if forward '(point-min) '(point-max)))
          (unwind-protect
-             (setq result (funcall search-fun string bound noerror count))
+             (setq result (funcall search-fun string (1- start) noerror count))
            (unless result
              (goto-char start))))
        result)))


### PR DESCRIPTION
`evil-search-function` performs an initial search starting from point.  If that search fails and search wrapping is enabled, `evil-search-function` then performs a second search, this time from the start of the buffer.  However, `evil-search-function` was using the same bound for both searches.  This commit changes `evil-search-function` to use the first search's starting position as the search bound for the second search.

This commit fixes issue #843.

* `evil-search.el` (`evil-search-function`): Use the initial search's start as the bound for the second search when searching wraps.