### PR TITLE
evil-show-registers: Show macros stored as vectors

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3083,10 +3083,11 @@ If ARG is nil this function calls `recompile', otherwise it calls
     :entries
     (cl-loop for (key . val) in (evil-register-list)
              collect `(nil [,(char-to-string key)
-                            ,(or (and val
-                                      (stringp val)
-                                      (replace-regexp-in-string "\n" "^J" val))
-                                 "")]))))
+                            ,(cond ((stringp val)
+                                    (replace-regexp-in-string "\n" "^J" val))
+				   ((vectorp val)
+				    (key-description val))
+				   (t ""))]))))
 
 (evil-define-command evil-show-marks (mrks)
   "Shows all marks.


### PR DESCRIPTION
When displaying register contents, `evil-show-registers` substitutes the empty string for non-string values.  If a register contains a macro, then the value is a key sequence, and a key sequence may be represented by either a string or a vector.  The latter would be substituted by the empty string.

This commit checks for vector values and uses `key-description` to display them.

* `evil-commands.el` (`evil-show-registers`): If a register contains a vector, display it by calling `key-description`.