### PR TITLE
Refine vdiff folding

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1634,6 +1634,13 @@ Elements have the form (NAME . FUNCTION).")
      :open       ,(lambda () (call-interactively 'vdiff-open-fold))
      :open-rec   ,(lambda () (call-interactively 'vdiff-open-fold))
      :close      ,(lambda () (call-interactively 'vdiff-close-fold)))
+    ((vdiff-3way-mode)
+     :open-all   vdiff-open-all-folds
+     :close-all  vdiff-close-all-folds
+     :toggle     nil
+     :open       ,(lambda () (call-interactively 'vdiff-open-fold))
+     :open-rec   ,(lambda () (call-interactively 'vdiff-open-fold))
+     :close      ,(lambda () (call-interactively 'vdiff-close-fold)))
     ((hs-minor-mode)
      :open-all   hs-show-all
      :close-all  hs-hide-all

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1627,7 +1627,14 @@ Elements have the form (NAME . FUNCTION).")
 (declare-function origami-close-node "origami.el")
 
 (defvar evil-fold-list
-  `(((hs-minor-mode)
+  `(((vdiff-mode)
+     :open-all   vdiff-open-all-folds
+     :close-all  vdiff-close-all-folds
+     :toggle     nil
+     :open       ,(lambda () (call-interactively 'vdiff-open-fold))
+     :open-rec   ,(lambda () (call-interactively 'vdiff-open-fold))
+     :close      ,(lambda () (call-interactively 'vdiff-close-fold)))
+    ((hs-minor-mode)
      :open-all   hs-show-all
      :close-all  hs-hide-all
      :toggle     hs-toggle-hiding
@@ -1661,14 +1668,7 @@ Elements have the form (NAME . FUNCTION).")
      :toggle     ,(lambda () (origami-toggle-node (current-buffer) (point)))
      :open       ,(lambda () (origami-open-node (current-buffer) (point)))
      :open-rec   ,(lambda () (origami-open-node-recursively (current-buffer) (point)))
-     :close      ,(lambda () (origami-close-node (current-buffer) (point))))
-    ((vdiff-mode)
-     :open-all   vdiff-open-all-folds
-     :close-all  vdiff-close-all-folds
-     :toggle     nil
-     :open       ,(lambda () (call-interactively 'vdiff-open-fold))
-     :open-rec   ,(lambda () (call-interactively 'vdiff-open-fold))
-     :close      ,(lambda () (call-interactively 'vdiff-close-fold))))
+     :close      ,(lambda () (origami-close-node (current-buffer) (point)))))
   "Actions to be performed for various folding operations.
 
 The value should be a list of fold handlers, were a fold handler has


### PR DESCRIPTION
This PR improves vdiff folding integration - vdiff is moved higher in`evil-fold-list`, making it take precedence over other folding modes. This makes sense because a user might have "long-lived" modes such as outline-mode/origami-mode always enabled and occasionally use vdiff which is a "short-lived" mode - there's no point in keeping vdiff enabled all the time. As a result, when the user is vdiff-ing a buffer which also happens to have outline-mode on, `zo` will open folds using vdiff instead of outline.

This PR also adds vdiff-3way-mode to `evil-fold-list`.

Refs https://github.com/emacs-evil/evil-collection/pull/179