### PR TITLE
Split keybindings out from evil-integration

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -25,6 +25,12 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Evil.  If not, see <http://www.gnu.org/licenses/>.
 
+
+;;; Commentary:
+;; This provides evil integration for various emacs modes.
+;; Additional keybindings (or default state) should go into evil-keybindings.el.
+;; If you want to use Evil in the minibuffer, you'll have to enable it by
+
 (require 'evil-maps)
 (require 'evil-core)
 (require 'evil-macros)
@@ -90,62 +96,11 @@
   (when (fboundp 'evil-repeat-abort)
     (evil-repeat-abort)))
 
-;; etags-select
-;; FIXME: probably etags-select should be recomended in docs
-(eval-after-load 'etags-select
-  '(progn
-     (define-key evil-motion-state-map "g]" 'etags-select-find-tag-at-point)))
-
-;;; Buffer-menu
-
-(evil-add-hjkl-bindings Buffer-menu-mode-map 'motion)
-
-;; dictionary.el
-
-(evil-add-hjkl-bindings dictionary-mode-map 'motion
-  "?" 'dictionary-help        ; "h"
-  "C-o" 'dictionary-previous) ; "l"
-
-;;; Dired
-
-(eval-after-load 'dired
-  '(progn
-     ;; use the standard Dired bindings as a base
-     (defvar dired-mode-map)
-     (evil-make-overriding-map dired-mode-map 'normal)
-     (evil-add-hjkl-bindings dired-mode-map 'normal
-       "J" 'dired-goto-file                   ; "j"
-       "K" 'dired-do-kill-lines               ; "k"
-       "r" 'dired-do-redisplay                ; "l"
-       ;; ":d", ":v", ":s", ":e"
-       ";" (lookup-key dired-mode-map ":"))))
-
 (eval-after-load 'wdired
   '(progn
      (add-hook 'wdired-mode-hook #'evil-change-to-initial-state)
      (defadvice wdired-change-to-dired-mode (after evil activate)
        (evil-change-to-initial-state nil t))))
-
-;;; ELP
-
-(eval-after-load 'elp
-  '(defadvice elp-results (after evil activate)
-     (evil-motion-state)))
-
-;;; ERT
-
-(evil-add-hjkl-bindings ert-results-mode-map 'motion)
-
-;;; Info
-
-(evil-add-hjkl-bindings Info-mode-map 'motion
-  "0" 'evil-digit-argument-or-evil-beginning-of-line
-  (kbd "\M-h") 'Info-help   ; "h"
-  "\C-t" 'Info-history-back ; "l"
-  "\C-o" 'Info-history-back
-  " " 'Info-scroll-up
-  "\C-]" 'Info-follow-nearest-node
-  (kbd "DEL") 'Info-scroll-down)
 
 ;;; Parentheses
 
@@ -183,29 +138,6 @@
                       show-paren-overlay-1))
           (let ((ov (and (boundp ov) (symbol-value ov))))
             (when (overlayp ov) (delete-overlay ov))))))))
-
-;;; Speedbar
-
-(evil-add-hjkl-bindings speedbar-key-map 'motion
-  "h" 'backward-char
-  "j" 'speedbar-next
-  "k" 'speedbar-prev
-  "l" 'forward-char
-  "i" 'speedbar-item-info
-  "r" 'speedbar-refresh
-  "u" 'speedbar-up-directory
-  "o" 'speedbar-toggle-line-expansion
-  (kbd "RET") 'speedbar-edit-line)
-
-;; Ibuffer
-(eval-after-load 'ibuffer
-  '(progn
-     (defvar ibuffer-mode-map)
-     (evil-make-overriding-map ibuffer-mode-map 'normal)
-     (evil-define-key 'normal ibuffer-mode-map
-       "j" 'evil-next-line
-       "k" 'evil-previous-line
-       "RET" 'ibuffer-visit-buffer)))
 
 ;;; Undo tree
 (when (and (require 'undo-tree nil t)
@@ -555,13 +487,6 @@ Based on `evil-enclose-ace-jump-for-motion'."
 (eval-after-load 'mumamo
   '(with-no-warnings
      (push 'evil-mode-cmhh mumamo-change-major-mode-no-nos)))
-
-;;; ag.el
-(eval-after-load 'ag
-  '(progn
-     (defvar ag-mode-map)
-     (add-to-list 'evil-motion-state-modes 'ag-mode)
-     (evil-add-hjkl-bindings ag-mode-map 'motion)))
 
 ;; visual-line-mode integration
 (when evil-respect-visual-line-mode

--- a/evil-keybindings.el
+++ b/evil-keybindings.el
@@ -1,0 +1,121 @@
+;;; evil-keybindings.el --- Add some Evil keybindings to other modules
+
+;; Author: Vegard Øye <vegard_oye at hotmail.com>
+;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
+
+;; Version: 1.2.13
+
+;;
+;; This file is NOT part of GNU Emacs.
+
+;;; License:
+
+;; This file is part of Evil.
+;;
+;; Evil is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; Evil is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Evil.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; This provides a set of keybindings for other emacs modes. This also includes
+;; setting up the initial evil state of those other modes.
+
+(require 'evil-maps)
+(require 'evil-core)
+(require 'evil-macros)
+(require 'evil-types)
+(require 'evil-repeat)
+
+;; etags-select
+;; FIXME: probably etags-select should be recomended in docs
+(eval-after-load 'etags-select
+  '(progn
+     (define-key evil-motion-state-map "g]" 'etags-select-find-tag-at-point)))
+
+;;; Buffer-menu
+
+(evil-add-hjkl-bindings Buffer-menu-mode-map 'motion)
+
+;; dictionary.el
+
+(evil-add-hjkl-bindings dictionary-mode-map 'motion
+  "?" 'dictionary-help        ; "h"
+  "C-o" 'dictionary-previous) ; "l"
+
+;;; Dired
+
+(eval-after-load 'dired
+  '(progn
+     ;; use the standard Dired bindings as a base
+     (defvar dired-mode-map)
+     (evil-make-overriding-map dired-mode-map 'normal)
+     (evil-add-hjkl-bindings dired-mode-map 'normal
+       "J" 'dired-goto-file                   ; "j"
+       "K" 'dired-do-kill-lines               ; "k"
+       "r" 'dired-do-redisplay                ; "l"
+       ;; ":d", ":v", ":s", ":e"
+       ";" (lookup-key dired-mode-map ":"))))
+
+;;; ERT
+
+(evil-add-hjkl-bindings ert-results-mode-map 'motion)
+
+;;; Info
+
+(evil-add-hjkl-bindings Info-mode-map 'motion
+  "0" 'evil-digit-argument-or-evil-beginning-of-line
+  (kbd "\M-h") 'Info-help   ; "h"
+  "\C-t" 'Info-history-back ; "l"
+  "\C-o" 'Info-history-back
+  " " 'Info-scroll-up
+  "\C-]" 'Info-follow-nearest-node
+  (kbd "DEL") 'Info-scroll-down)
+
+;;; Speedbar
+
+(evil-add-hjkl-bindings speedbar-key-map 'motion
+  "h" 'backward-char
+  "j" 'speedbar-next
+  "k" 'speedbar-prev
+  "l" 'forward-char
+  "i" 'speedbar-item-info
+  "r" 'speedbar-refresh
+  "u" 'speedbar-up-directory
+  "o" 'speedbar-toggle-line-expansion
+  (kbd "RET") 'speedbar-edit-line)
+
+;; Ibuffer
+(eval-after-load 'ibuffer
+  '(progn
+     (defvar ibuffer-mode-map)
+     (evil-make-overriding-map ibuffer-mode-map 'normal)
+     (evil-define-key 'normal ibuffer-mode-map
+       "j" 'evil-next-line
+       "k" 'evil-previous-line
+       "RET" 'ibuffer-visit-buffer)))
+
+;;; ag.el
+(eval-after-load 'ag
+  '(progn
+     (defvar ag-mode-map)
+     (add-to-list 'evil-motion-state-modes 'ag-mode)
+     (evil-add-hjkl-bindings ag-mode-map 'motion)))
+
+;;; ELP
+
+(eval-after-load 'elp
+  '(defadvice elp-results (after evil activate)
+     (evil-motion-state)))
+
+(provide 'evil-keybindings)
+
+;;; evil-keybindings.el ends here

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1877,6 +1877,16 @@ This variable must be set before Evil is loaded."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-want-keybinding t
+  "Whether to load evil-keybindings.el.
+
+This loads a set of keybindings for evil in other modes as well as
+setting the initial evil state in those modes.
+
+This variable must be set before evil is loaded."
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-want-minibuffer nil
   "Whether to enable Evil in minibuffer(s)."
   :type 'boolean

--- a/evil.el
+++ b/evil.el
@@ -141,6 +141,9 @@
 (when evil-want-integration
   (require 'evil-integration))
 
+(when evil-want-keybinding
+  (require 'evil-keybindings))
+
 (run-hooks 'evil-after-load-hook)
 
 (provide 'evil)


### PR DESCRIPTION
@edkolev @ambrevar @noctuid @justbur @wasamasa @syl20bnr @TheBB 

Following from: https://github.com/emacs-evil/evil-collection/issues/60

Most everyone seems to be on board to pull the keybindings out so that evil-collection can more easily leverage evil's evil-integration.el.

I took a quick look and pulled out the keybindings from evil-integration and put them in a separate file.

Any comments appreciated!
