### PR TITLE
Fix `evil-ex` called with a current line prefix

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -170,7 +170,7 @@ is appended to the line."
                 (let ((arg (prefix-numeric-value current-prefix-arg)))
                   (cond ((< arg 0) (setq arg (1+ arg)))
                         ((> arg 0) (setq arg (1- arg))))
-                  (if (= arg 0) '(".")
+                  (if (= arg 0) "."
                     (format ".,.%+d" arg)))))
               evil-ex-initial-input)))
       (and (> (length s) 0) s))))


### PR DESCRIPTION
Previously when a current line prefix was specified (i.e.
giving a numeric argument of 1 before calling `evil-ex`),
Ex attempted to `concat` together a string wrapped in a
list with `evil-ex-initial-input`, but if `concat` is
passed a list it expects it to be a list of characters not
strings.