### PR TITLE
Fix bug with evil-swap-marker for global markers

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1927,11 +1927,11 @@ otherwise, it stays behind."
           (setq alist (default-value 'evil-markers-alist)
                 marker (make-marker))
           (evil-add-to-alist 'alist char marker)
-          (setq-default evil-markers-alist alist))
+          (setq-default evil-markers-alist alist)
+          (add-hook 'kill-buffer-hook #'evil-swap-out-markers nil t))
          (t
           (setq marker (make-marker))
           (evil-add-to-alist 'evil-markers-alist char marker))))
-      (add-hook 'kill-buffer-hook #'evil-swap-out-markers nil t)
       (set-marker-insertion-type marker advance)
       (set-marker marker (or pos (point))))))
 
@@ -1967,8 +1967,8 @@ or a marker object pointing nowhere."
 
 (defun evil-swap-out-markers ()
   "Turn markers into file references when the buffer is killed."
-  (and buffer-file-name
-       (dolist (entry evil-markers-alist)
+  (when buffer-file-name
+       (dolist (entry (default-value 'evil-markers-alist))
          (and (markerp (cdr entry))
               (eq (marker-buffer (cdr entry)) (current-buffer))
               (setcdr entry (cons buffer-file-name

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8328,6 +8328,31 @@ when an error stops the execution of the macro"
     (test-3-mode)
     (should (eq evil-state 'insert))))
 
+(ert-deftest evil-test-marker ()
+  "Test `evil-test-marker'"
+  :tags '(evil)
+  (ert-info ("Set a local mark")
+    (evil-test-buffer
+      "[f]oo\nbar\nbaz"
+      ("ma" "j")
+      "foo\n[b]ar\nbaz"
+      ("'a")
+      "[f]oo\nbar\nbaz"))
+  (ert-info ("Set a global mark")
+    (evil-test-buffer
+      "foo\n[b]ar\nbaz"
+      ("mA" "k")
+      "[f]oo\nbar\nbaz"
+      ("'A")
+      "foo\n[b]ar\nbaz"))
+  (ert-info ("Persist global marks on buffer close")
+    (evil-test-buffer
+      "foo\n[b]ar\nbaz"
+      ("ma" "mA")
+      (write-file (make-temp-file "tmp"))
+      (kill-buffer)
+      (should (alist-get ?A evil-markers-alist)))))
+
 (provide 'evil-tests)
 
 ;;; evil-tests.el ends here


### PR DESCRIPTION
This fixes a bug with the `evil-swap-marker` implementation currently in evil.

**Reproduction**

- Open a file
- Create a local marker using `m a`
- Create a global marker using `m A` elsewhere
- Kill the buffer
- Fails to navigate to the buffer using `' A`