### PR TITLE
Xref should be called with identifier instead of symbol at point

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2685,7 +2685,8 @@ The search is unbounded, i.e., the pattern is not wrapped in
                (ignore-errors (semantic-ia-fast-jump ipos)))
           ()) ;; noop, already jumped
          ((fboundp 'xref-find-definitions) ;; semantic failed, try the generic func
-          (xref-find-definitions string))))
+          (xref-find-definitions (xref-backend-identifier-at-point
+                                  (xref-find-backend))))))
        ;; otherwise just go to first occurrence in buffer
        (t
         (evil-search search t t (point-min)))))))


### PR DESCRIPTION
`evil-goto-definition` uses `(xref-find-definition (symbol-at-point))` as fallback to find the definition of the symbol at point.

According to (my understanding of) xref documentation, `xref-find-definition` should take an identifier as argument, which can be different than the symbol at point. The good way to call `xref-find-definitions` would then be the following:

```Elisp
(xref-find-definitions (xref-backend-identifier-at-point (xref-find-backend)))
```

This PR just correct this.

Here the relevant part of the xref doc for reference:
```
;; This file provides a somewhat generic infrastructure for cross
;; referencing commands, in particular "find-definition".
;;
;; Some part of the functionality must be implemented in a language
;; dependent way and that's done by defining an xref backend.
;;
;; That consists of a constructor function, which should return a
;; backend value, and a set of implementations for the generic
;; functions:
;;
;; `xref-backend-identifier-at-point',
;; `xref-backend-identifier-completion-table',
;; `xref-backend-definitions', `xref-backend-references',
;; `xref-backend-apropos', which see.
[...]
;; Each identifier must be represented as a string.  Implementers can
;; use string properties to store additional information about the
;; identifier, but they should keep in mind that values returned from
;; `xref-backend-identifier-completion-table' should still be
;; distinct, because the user can't see the properties when making the
;; choice.
```

(This follows a bug reported in Elpy [here](https://github.com/jorgenschaefer/elpy/issues/1483).)