### PR TITLE
Allow C-g to abort evil-read-key

### DIFF
--- a/evil-maps.el
+++ b/evil-maps.el
@@ -546,6 +546,7 @@ included in `evil-insert-state-bindings' by default."
 ;; evil-read-key
 (define-key evil-read-key-map (kbd "ESC") #'keyboard-quit)
 (define-key evil-read-key-map (kbd "C-]") #'keyboard-quit)
+(define-key evil-read-key-map (kbd "C-g") #'keyboard-quit)
 (define-key evil-read-key-map (kbd "C-q") #'evil-read-quoted-char)
 (define-key evil-read-key-map (kbd "C-v") #'evil-read-quoted-char)
 (define-key evil-read-key-map (kbd "C-k") #'evil-read-digraph-char)


### PR DESCRIPTION
This prevents evil-replace from inserting a literal C-g if C-g is typed after
entering replace state.