### PR TITLE
Better integration of window manipulation commands

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3834,6 +3834,18 @@ The 'bang' argument means to sort in reverse order."
 
 ;;; Window navigation
 
+(defmacro evil-save-side-windows (&rest body)
+  "Toggle side windows, evaluate BODY, restore side windows."
+  (declare (indent defun) (debug (&rest form)))
+  (let ((sides (make-symbol "sidesvar")))
+    `(let ((,sides (and (functionp 'window-toggle-side-windows)
+                        (window-with-parameter 'window-side))))
+       (when ,sides
+         (window-toggle-side-windows))
+       ,@body
+       (when ,sides
+         (window-toggle-side-windows)))))
+
 (defun evil-resize-window (new-size &optional horizontal)
   "Set the current window's width or height to NEW-SIZE.
 If HORIZONTAL is non-nil the width of the window is changed,
@@ -3841,28 +3853,35 @@ otherwise its height is changed."
   (let ((count (- new-size (if horizontal (window-width) (window-height)))))
     (enlarge-window count horizontal)))
 
-(defun evil-get-buffer-tree (wintree)
-  "Extracts the buffer tree from a given window tree WINTREE."
-  (if (consp wintree)
-      (cons (car wintree) (mapcar #'evil-get-buffer-tree (cddr wintree)))
-    (window-buffer wintree)))
+(defun evil-move-window (side)
+  "Move the `selected-window' to SIDE.
+The state of the `selected-window' is saved along with the state
+of the window tree consisting of all the other windows. Then, all
+windows are deleted, the remaining window is split according to
+SIDE, the state of the window at SIDE is replaced with the saved
+state of the `selected-window', and, finally, the state of the
+saved window tree is reconstructed on the opposite side.
 
-(defun evil-restore-window-tree (win tree)
-  "Restore the given buffer-tree layout as subwindows of WIN.
-TREE is the tree layout to be restored.
-A tree layout is either a buffer or a list of the form (DIR TREE ...),
-where DIR is t for horizontal split and nil otherwise. All other
-elements of the list are tree layouts itself."
-  (if (bufferp tree)
-      (set-window-buffer win tree)
-    ;; if tree is buffer list with one buffer only, do not split
-    ;; anymore
-    (if (not (cddr tree))
-        (evil-restore-window-tree win (cadr tree))
-      ;; tree is a regular list, split recursively
-      (let ((newwin (split-window win nil (not (car tree)))))
-        (evil-restore-window-tree win (cadr tree))
-        (evil-restore-window-tree newwin (cons (car tree) (cddr tree)))))))
+SIDE has the same meaning as in `split-window'.
+
+Note, this function only operates on the window tree rooted in
+the frame's main window and effectively preserves any side
+windows \(i.e. windows with a valid window-side window
+parameter\)."
+  (evil-save-side-windows
+    (unless (one-window-p)
+      (save-excursion
+        (let ((w (window-state-get (selected-window))))
+          (delete-window)
+          (let ((wtree (window-state-get)))
+            (delete-other-windows)
+            (let ((subwin (selected-window))
+                  ;; NOTE: SIDE is new in Emacs 24
+                  (newwin (split-window nil nil side)))
+              (window-state-put wtree subwin)
+              (window-state-put w newwin)
+              (select-window newwin)))))
+      (balance-windows))))
 
 (defun evil-alternate-buffer (&optional window)
   "Return the last buffer WINDOW has displayed other than the
@@ -4141,98 +4160,54 @@ If ARG is empty, maximize the current window height."
         (evil-window-decrease-height (- n))))))
 
 (evil-define-command evil-window-rotate-upwards ()
-  "Rotates the windows according to the currenty cyclic ordering."
+  "Rotates the windows according to the current cyclic ordering."
   :repeat nil
-  (let ((wlist (window-list))
-        (blist (mapcar #'(lambda (w) (window-buffer w))
-                       (window-list))))
-    (setq blist (append (cdr blist) (list (car blist))))
-    (while (and wlist blist)
-      (set-window-buffer (car wlist) (car blist))
-      (setq wlist (cdr wlist)
-            blist (cdr blist)))
-    (select-window (car (last (window-list))))))
+  (evil-save-side-windows
+    (let ((wlist (window-list))
+          (slist (mapcar #'window-state-get (window-list))))
+      (setq slist (append (cdr slist) (list (car slist))))
+      (while (and wlist slist)
+        (window-state-put (car slist) (car wlist))
+        (setq wlist (cdr wlist)
+              slist (cdr slist)))
+      (select-window (car (last (window-list)))))))
 
 (evil-define-command evil-window-rotate-downwards ()
-  "Rotates the windows according to the currenty cyclic ordering."
+  "Rotates the windows according to the current cyclic ordering."
   :repeat nil
-  (let ((wlist (window-list))
-        (blist (mapcar #'(lambda (w) (window-buffer w))
-                       (window-list))))
-    (setq blist (append (last blist) blist))
-    (while (and wlist blist)
-      (set-window-buffer (car wlist) (car blist))
-      (setq wlist (cdr wlist)
-            blist (cdr blist)))
-    (select-window (cadr (window-list)))))
+  (evil-save-side-windows
+    (let ((wlist (window-list))
+          (slist (mapcar #'window-state-get (window-list))))
+      (setq slist (append (last slist) slist))
+      (while (and wlist slist)
+        (window-state-put (car slist) (car wlist))
+        (setq wlist (cdr wlist)
+              slist (cdr slist)))
+      (select-window (cadr (window-list))))))
 
 (evil-define-command evil-window-move-very-top ()
   "Closes the current window, splits the upper-left one horizontally
 and redisplays the current buffer there."
   :repeat nil
-  (unless (one-window-p)
-    (save-excursion
-      (let ((b (current-buffer)))
-        (delete-window)
-        (let ((btree (evil-get-buffer-tree (car (window-tree)))))
-          (delete-other-windows)
-          (let ((newwin (selected-window))
-                (subwin (split-window)))
-            (evil-restore-window-tree subwin btree)
-            (set-window-buffer newwin b)
-            (select-window newwin)))))
-    (balance-windows)))
+  (evil-move-window 'above))
 
 (evil-define-command evil-window-move-far-left ()
   "Closes the current window, splits the upper-left one vertically
 and redisplays the current buffer there."
   :repeat nil
-  (unless (one-window-p)
-    (save-excursion
-      (let ((b (current-buffer)))
-        (delete-window)
-        (let ((btree (evil-get-buffer-tree (car (window-tree)))))
-          (delete-other-windows)
-          (let ((newwin (selected-window))
-                (subwin (split-window-horizontally)))
-            (evil-restore-window-tree subwin btree)
-            (set-window-buffer newwin b)
-            (select-window newwin)))))
-    (balance-windows)))
+  (evil-move-window 'left))
 
 (evil-define-command evil-window-move-far-right ()
   "Closes the current window, splits the lower-right one vertically
 and redisplays the current buffer there."
   :repeat nil
-  (unless (one-window-p)
-    (save-excursion
-      (let ((b (current-buffer)))
-        (delete-window)
-        (let ((btree (evil-get-buffer-tree (car (window-tree)))))
-          (delete-other-windows)
-          (let ((subwin (selected-window))
-                (newwin (split-window-horizontally)))
-            (evil-restore-window-tree subwin btree)
-            (set-window-buffer newwin b)
-            (select-window newwin)))))
-    (balance-windows)))
+  (evil-move-window 'right))
 
 (evil-define-command evil-window-move-very-bottom ()
   "Closes the current window, splits the lower-right one horizontally
 and redisplays the current buffer there."
   :repeat nil
-  (unless (one-window-p)
-    (save-excursion
-      (let ((b (current-buffer)))
-        (delete-window)
-        (let ((btree (evil-get-buffer-tree (car (window-tree)))))
-          (delete-other-windows)
-          (let ((subwin (selected-window))
-                (newwin (split-window)))
-            (evil-restore-window-tree subwin btree)
-            (set-window-buffer newwin b)
-            (select-window newwin)))))
-    (balance-windows)))
+  (evil-move-window 'below))
 
 ;;; Mouse handling
 

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3842,9 +3842,10 @@ The 'bang' argument means to sort in reverse order."
                         (window-with-parameter 'window-side))))
        (when ,sides
          (window-toggle-side-windows))
-       ,@body
-       (when ,sides
-         (window-toggle-side-windows)))))
+       (unwind-protect
+           (progn ,@body)
+         (when ,sides
+           (window-toggle-side-windows))))))
 
 (defun evil-resize-window (new-size &optional horizontal)
   "Set the current window's width or height to NEW-SIZE.


### PR DESCRIPTION
Commands like `evil-window-rotate-upwards` and `evil-window-move-very-top` only
consider the buffer in each window when manipulating the window tree, but if a
window has specific window properties that need to be maintained (like those in
`window-persistent-parameters`) that information is lost.

Refactor the window manipulation commands to use `window-state-get` and
`window-state-put` to retrieved and restore the state of the window tree so
that window properties in each window are maintained.

Also integrate the window manipulation commands with side windows, i.e. windows
with a non-nil `window-side` window parameter, by only manipulating the part of
the window tree that are not side windows.

* Add the macro `evil-save-side-windows` which removes all side windows on
  entering the macro environment and restores the side windows leaving.

* Add the function `evil-move-window` which does the work of
  `evil-window-move-far-left`, `evil-window-move-very-top`,
  `evil-window-move-far-right`, and `evil-window-move-very-bottom`. These
  functions were all identical, the only difference being which window was used
  to restore the `selected-window`.

* Use `window-state-(get|put)` to get the window tree and to restore it. This
  makes `evil-get-buffer-tree` and `evil-restore-window-tree` unnecessary and
  they are removed. Note that `window-state-(get|put)` also handles window
  parameters.

* In addition to ignoring side windows when moving a window, ignore them in
  `evil-window-rotate-downwards` and `evil-window-rotate-upwards`.