### PR TITLE
add option evil-ex-search-skip-matches-under-point

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -981,6 +981,9 @@ any error conditions."
       (with-current-buffer evil-ex-current-buffer
         (with-selected-window (minibuffer-selected-window)
           (goto-char (1+ evil-ex-search-start-point))
+          (when (and (eq evil-ex-search-direction 'forward)
+                     (not evil-ex-search-skip-matches-under-point))
+            (forward-char -1))
           (condition-case err
               (let* ((result (evil-ex-search-full-pattern pattern-string
                                                           (or evil-ex-search-count 1)
@@ -1087,6 +1090,10 @@ current search result."
                  (signal (car err) (cdr err))))))
         ;; pattern entered successful
         (goto-char (1+ evil-ex-search-start-point))
+        (when (and (eq evil-ex-search-direction 'forward)
+                     (not evil-ex-search-skip-matches-under-point))
+          (forward-char -1))
+
         (let* ((result
                 (evil-ex-search-full-pattern search-string
                                              evil-ex-search-count

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1109,6 +1109,12 @@ codes.  Note that this only affects the search command if
 always uses plain Emacs regular expressions."
   :type 'boolean
   :group 'evil)
+(defcustom evil-ex-search-skip-matches-under-point t
+  "Whether skips matches that don't move the cursor.
+Note that this only affects the search command
+if `evil-search-module' is set to 'evil-search."
+  :type 'boolean
+  :group 'evil)
 
 (defcustom evil-ex-interactive-search-highlight 'all-windows
   "Determine in which windows the interactive highlighting should be shown."


### PR DESCRIPTION
Note that this only affects the search command
if `evil-search-module' is set to 'evil-search.

```
(setq  evil-search-module 'evil-search)
```
this is similar to option `evil-move-cursor-back` 
