### PR TITLE
Clone shallow repository in README.md#download

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ extensions. Also see our page on [EmacsWiki](http://emacswiki.org/emacs/Evil).
 Evil lives in a git repository. To download Evil, do
 
 ```
-git clone https://github.com/emacs-evil/evil ~/.emacs.d/evil
+git clone --depth 1 https://github.com/emacs-evil/evil ~/.emacs.d/evil
 ```
 
 # Install


### PR DESCRIPTION
Full repository is 43MB as of now, shallow copy with only the latest commit is 2.9MB.

Majority of people who clone the repository through the README.md do so for the purpose of using evil, not modifying it. There's no need to make them download the whole repository.