### PR TITLE
Treat all commands that change the current buffer as jump commands

### DIFF
--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -311,10 +311,25 @@ change the current buffer."
                (previous-pos (evil-jumps-struct-previous-pos struct)))
           (when previous-pos
             (setf (evil-jumps-struct-previous-pos struct) nil)
-            (if (and (not jumping-backward)
-                     (let ((previous-buffer (marker-buffer previous-pos)))
-                       (and previous-buffer
-                            (not (eq previous-buffer (window-buffer window))))))
+            (if (and
+                 ;; `evil-jump-backward' (and other backward jumping
+                 ;; commands) needs to be handled specially. When
+                 ;; jumping backward multiple times, calling
+                 ;; `evil-set-jump' is always wrong: If you jump back
+                 ;; twice and we call `evil-set-jump' after the second
+                 ;; time, we clear the forward jump list and
+                 ;; `evil--jump-forward' won't work.
+
+                 ;; The first time you jump backward, setting a jump
+                 ;; point is sometimes correct. But we don't do it
+                 ;; here because this function is called after
+                 ;; `evil--jump-backward' has updated our position in
+                 ;; the jump list so, again, `evil-set-jump' would
+                 ;; break `evil--jump-forward'.
+                 (not jumping-backward)
+                 (let ((previous-buffer (marker-buffer previous-pos)))
+                   (and previous-buffer
+                        (not (eq previous-buffer (window-buffer window))))))
                 (evil-set-jump previous-pos)
               (set-marker previous-pos nil))))))))
 

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -304,17 +304,17 @@ POS defaults to point."
     (evil--jumps-savehist-load)
   (add-hook 'savehist-mode-hook #'evil--jumps-savehist-load))
 
-(add-hook 'evil-local-mode-hook
-          (lambda ()
-            (if evil-local-mode
-                (progn
-                  (add-hook 'pre-command-hook #'evil--jump-hook nil t)
-                  (add-hook 'next-error-hook #'evil-set-jump nil t)
-                  (add-hook 'window-configuration-change-hook #'evil--jumps-window-configuration-hook nil t))
-              (progn
-                (remove-hook 'pre-command-hook #'evil--jump-hook t)
-                (remove-hook 'next-error-hook #'evil-set-jump t)
-                (remove-hook 'window-configuration-change-hook #'evil--jumps-window-configuration-hook t)))))
+(defun evil--jumps-install-or-uninstall ()
+  (if evil-local-mode
+      (progn
+        (add-hook 'pre-command-hook #'evil--jump-hook nil t)
+        (add-hook 'next-error-hook #'evil-set-jump nil t)
+        (add-hook 'window-configuration-change-hook #'evil--jumps-window-configuration-hook nil t))
+    (remove-hook 'pre-command-hook #'evil--jump-hook t)
+    (remove-hook 'next-error-hook #'evil-set-jump t)
+    (remove-hook 'window-configuration-change-hook #'evil--jumps-window-configuration-hook t)))
+
+(add-hook 'evil-local-mode-hook #'evil--jumps-install-or-uninstall)
 
 (provide 'evil-jumps)
 

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -81,11 +81,12 @@
   ring
   (idx -1))
 
-(defmacro evil--jumps-message (format &rest args)
-  (when evil--jumps-debug
-    `(with-current-buffer (get-buffer-create "*evil-jumps*")
+;; Is inlining this really worth it?
+(defsubst evil--jumps-message (format &rest args)
+  (when (eval-when-compile evil--jumps-debug)
+    (with-current-buffer (get-buffer-create "*evil-jumps*")
        (goto-char (point-max))
-       (insert (apply #'format ,format ',args) "\n"))))
+       (insert (apply #'format format args) "\n"))))
 
 (defun evil--jumps-get-current (&optional window)
   (unless window

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -219,18 +219,21 @@
 (defun evil-set-jump (&optional pos)
   "Set jump point at POS.
 POS defaults to point."
-  (unless (or (region-active-p) (evil-visual-state-p))
-    (push-mark pos t))
+  (save-excursion
+    (when (markerp pos)
+      (set-buffer (marker-buffer pos)))
 
-  (unless evil--jumps-jumping
-    ;; clear out intermediary jumps when a new one is set
-    (let* ((struct (evil--jumps-get-current))
-           (target-list (evil--jumps-get-jumps struct))
-           (idx (evil-jumps-struct-idx struct)))
-      (cl-loop repeat idx
-               do (ring-remove target-list))
-      (setf (evil-jumps-struct-idx struct) -1))
-    (save-excursion
+    (unless (or (region-active-p) (evil-visual-state-p))
+      (push-mark pos t))
+
+    (unless evil--jumps-jumping
+      ;; clear out intermediary jumps when a new one is set
+      (let* ((struct (evil--jumps-get-current))
+             (target-list (evil--jumps-get-jumps struct))
+             (idx (evil-jumps-struct-idx struct)))
+        (cl-loop repeat idx
+                 do (ring-remove target-list))
+        (setf (evil-jumps-struct-idx struct) -1))
       (when pos
         (goto-char pos))
       (evil--jumps-push))))

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -1,4 +1,4 @@
-;;; evil-jumps.el --- Jump list implementation
+;;; evil-jumps.el --- Jump list implementation -*- lexical-binding: t -*-
 
 ;; Author: Bailey Ling <bling at live.ca>
 
@@ -145,8 +145,7 @@
         ;; skip jump marks pointing to other buffers
         (while (and (< idx size) (>= idx 0)
                     (not (string= current-file-name
-                                  (let* ((place (ring-ref target-list idx))
-                                         (pos (car place)))
+                                  (let* ((place (ring-ref target-list idx)))
                                     (cadr place)))))
           (setq idx (+ idx shift))))
       (when (and (< idx size) (>= idx 0))
@@ -259,7 +258,7 @@ POS defaults to point."
           (evil--jumps-push))
           (evil--jumps-jump idx -1)))))
 
-(defun evil--jumps-window-configuration-hook (&rest args)
+(defun evil--jumps-window-configuration-hook (&rest _args)
   (let* ((window-list (window-list-1 nil nil t))
          (existing-window (selected-window))
          (new-window (previous-window)))
@@ -276,7 +275,7 @@ POS defaults to point."
               (setf (evil-jumps-struct-idx target-jump-struct) (evil-jumps-struct-idx source-jump-struct))
               (setf (evil-jumps-struct-ring target-jump-struct) (ring-copy source-list)))))))
     ;; delete obsolete windows
-    (maphash (lambda (key val)
+    (maphash (lambda (key _val)
                (unless (member key window-list)
                  (evil--jumps-message "removing %s" key)
                  (remhash key evil--jumps-window-jumps)))

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -68,6 +68,11 @@
   "Marker for Visual end.")
 (make-variable-buffer-local 'evil-test-visual-end)
 
+(defvaralias 'evil-test-select-enable-clipboard
+  (if (boundp 'select-enable-clipboard)
+      'select-enable-clipboard
+    'x-select-enable-clipboard))
+
 (defmacro evil-test-buffer (&rest body)
   "Execute FORMS in a temporary buffer.
 The following optional keywords specify the buffer's properties:
@@ -127,7 +132,7 @@ raised.  Remaining forms are evaluated as-is.
                     ',visual ,visual-start ,visual-end))
            (kill-ring kill-ring)
            (kill-ring-yank-pointer kill-ring-yank-pointer)
-           x-select-enable-clipboard
+           evil-test-select-enable-clipboard
            message-log-max)
        (unwind-protect
            (save-window-excursion

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8188,7 +8188,22 @@ maybe we need one line more with some text\n")
         ("\C-o")
         "z [z] z z z z z z"
         ("3\C-i") ;; even after jumping forward 3 times it can't get past the 3rd z
-        "z z [z] z z z z z"))))
+        "z z [z] z z z z z"))
+    (ert-info ("Jump across files")
+      (let ((temp-file (make-temp-file "evil-test-")))
+        (unwind-protect
+          (evil-test-buffer
+            "[z] z z z z z z"
+            ("\M-x" "find-file" [return] temp-file [return] "inew buffer" [escape])
+            "new buffe[r]"
+            ("\C-o")
+            "[z] z z z z z z"
+            ("\C-i")
+            "new buffe[r]")
+          (delete-file temp-file)
+          (with-current-buffer (get-file-buffer temp-file)
+            (set-buffer-modified-p nil))
+          (kill-buffer (get-file-buffer temp-file)))))))
 
 (ert-deftest evil-test-abbrev-expand ()
   :tags '(evil abbrev)


### PR DESCRIPTION
In Vim, all commands that change the current file are jump commands. Evil previously implemented this using advices, but this did not catch all applicable commands: find-file, for example, was ignored.

By checking if a command changed the buffer in the post-command-hook, we can reliably catch all of buffer-changing commands.

This pull request also enables lexical binding in evil-jumps.el and includes some other minor refactoring.