### PR TITLE
Fix behavior of evil-scroll-up and evil-scroll-down

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -956,7 +956,7 @@ If the scroll count is zero the command scrolls half the screen."
       (signal 'beginning-of-buffer nil))
     (when (zerop count)
       (setq count (/ (1- (window-height)) 2)))
-    (let ((xy (posn-x-y (posn-at-point))))
+    (let ((xy (evil-posn-x-y (posn-at-point))))
       (condition-case nil
           (progn
             (scroll-down count)
@@ -984,7 +984,7 @@ If the scroll count is zero the command scrolls half the screen."
     ;; In that case we do not scroll but merely move point.
     (if (<= (point-max) (window-end))
         (with-no-warnings (next-line count nil))
-      (let ((xy (posn-x-y (posn-at-point))))
+      (let ((xy (evil-posn-x-y (posn-at-point))))
         (condition-case nil
             (progn
               (scroll-up count)

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3816,25 +3816,7 @@ The 'bang' argument means to sort in reverse order."
 If HORIZONTAL is non-nil the width of the window is changed,
 otherwise its height is changed."
   (let ((count (- new-size (if horizontal (window-width) (window-height)))))
-    (if (>= emacs-major-version 24)
-        (enlarge-window count horizontal)
-      (let ((wincfg (current-window-configuration))
-            (nwins (length (window-list)))
-            (inhibit-redisplay t))
-        (catch 'done
-          (save-window-excursion
-            (while (not (zerop count))
-              (if (> count 0)
-                  (progn
-                    (enlarge-window 1 horizontal)
-                    (setq count (1- count)))
-                (progn
-                  (shrink-window 1 horizontal)
-                  (setq count (1+ count))))
-              (if (= nwins (length (window-list)))
-                  (setq wincfg (current-window-configuration))
-                (throw 'done t)))))
-        (set-window-configuration wincfg)))))
+    (enlarge-window count horizontal)))
 
 (defun evil-get-buffer-tree (wintree)
   "Extracts the buffer tree from a given window tree WINTREE."

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -955,7 +955,7 @@ If the scroll count is zero the command scrolls half the screen."
     (when (= (point-min) (line-beginning-position))
       (signal 'beginning-of-buffer nil))
     (when (zerop count)
-      (setq count (/ (1- (window-height)) 2)))
+      (setq count (/ (window-body-height) 2)))
     (let ((xy (evil-posn-x-y (posn-at-point))))
       (condition-case nil
           (progn
@@ -979,7 +979,7 @@ If the scroll count is zero the command scrolls half the screen."
     (setq evil-scroll-count count)
     (when (eobp) (signal 'end-of-buffer nil))
     (when (zerop count)
-      (setq count (/ (1- (window-height)) 2)))
+      (setq count (/ (window-body-height) 2)))
     ;; BUG #660: First check whether the eob is visible.
     ;; In that case we do not scroll but merely move point.
     (if (<= (point-max) (window-end))

--- a/evil-common.el
+++ b/evil-common.el
@@ -867,10 +867,6 @@ Inhibits echo area messages, mode line updates and cursor changes."
   `(let ((evil-no-display t))
      ,@body))
 
-(defun evil-num-visible-lines ()
-  "Returns the number of currently visible lines."
-  (- (window-height) 1))
-
 (defvar evil-cached-header-line-height nil
   "Cached height of the header line.")
 

--- a/evil-common.el
+++ b/evil-common.el
@@ -881,18 +881,15 @@ If there is no header line, return nil."
   "Return the x and y coordinates in POSITION.
 
 This function returns y offset from the top of the buffer area including
-the header line.  This definition could be changed in future.
-Note: On Emacs 22 and 23, y offset, returned by `posn-at-point' and taken
-by `posn-at-x-y', is relative to the top of the buffer area including
 the header line.
-However, on Emacs 24, y offset returned by `posn-at-point' is relative to
-the text area excluding the header line, while y offset taken by
-`posn-at-x-y' is relative to the buffer area including the header line.
+on Emacs 24 and later versions, y offset returned by `posn-at-point' is
+relative to the text area excluding the header line, while y offset taken
+by `posn-at-x-y' is relative to the buffer area including the header line.
 This asymmetry is by design according to GNU Emacs team.
-This function fixes the asymmetry between them on Emacs 24 and later versions.
-Borrowed from mozc.el."
+This function fixes the asymmetry between them.
+Learned from mozc.el."
   (let ((xy (posn-x-y position)))
-    (when (and (> emacs-major-version 24) header-line-format)
+    (when header-line-format
       (setcdr xy (+ (cdr xy)
                     (or evil-cached-header-line-height
                         (setq evil-cached-header-line-height (evil-header-line-height))

--- a/evil-common.el
+++ b/evil-common.el
@@ -871,6 +871,38 @@ Inhibits echo area messages, mode line updates and cursor changes."
   "Returns the number of currently visible lines."
   (- (window-height) 1))
 
+(defvar evil-cached-header-line-height nil
+  "Cached height of the header line.")
+
+(defun evil-header-line-height ()
+  "Return the height of the header line.
+If there is no header line, return nil."
+  (let ((posn (posn-at-x-y 0 0)))
+    (when (eq (posn-area posn) 'header-line)
+      (cdr (posn-object-width-height posn)))))
+
+(defun evil-posn-x-y (position)
+  "Return the x and y coordinates in POSITION.
+
+This function returns y offset from the top of the buffer area including
+the header line.  This definition could be changed in future.
+Note: On Emacs 22 and 23, y offset, returned by `posn-at-point' and taken
+by `posn-at-x-y', is relative to the top of the buffer area including
+the header line.
+However, on Emacs 24, y offset returned by `posn-at-point' is relative to
+the text area excluding the header line, while y offset taken by
+`posn-at-x-y' is relative to the buffer area including the header line.
+This asymmetry is by design according to GNU Emacs team.
+This function fixes the asymmetry between them on Emacs 24 and later versions.
+Borrowed from mozc.el."
+  (let ((xy (posn-x-y position)))
+    (when (and (> emacs-major-version 24) header-line-format)
+      (setcdr xy (+ (cdr xy)
+                    (or evil-cached-header-line-height
+                        (setq evil-cached-header-line-height (evil-header-line-height))
+                        0))))
+    xy))
+
 (defun evil-count-lines (beg end)
   "Return absolute line-number-difference betweeen `beg` and `end`.
 This should give the same results no matter where on the line `beg`

--- a/evil-common.el
+++ b/evil-common.el
@@ -879,14 +879,15 @@ If there is no header line, return nil."
 
 (defun evil-posn-x-y (position)
   "Return the x and y coordinates in POSITION.
-
 This function returns y offset from the top of the buffer area including
 the header line.
-on Emacs 24 and later versions, y offset returned by `posn-at-point' is
-relative to the text area excluding the header line, while y offset taken
-by `posn-at-x-y' is relative to the buffer area including the header line.
-This asymmetry is by design according to GNU Emacs team.
-This function fixes the asymmetry between them.
+
+On Emacs 24 and later versions, the y-offset returned by
+`posn-at-point' is relative to the text area excluding the header
+line, while y offset taken by `posn-at-x-y' is relative to the buffer
+area including the header line.  This asymmetry is by design according
+to GNU Emacs team.  This function fixes the asymmetry between them.
+
 Learned from mozc.el."
   (let ((xy (posn-x-y position)))
     (when header-line-format


### PR DESCRIPTION
When header line is enabled, `evil-scroll-up` and `evil-scroll-down` won't remain in the same position when scroll.
```
From my investigation, the root cause was as follows.

On Emacs 24 with non-nil header-line-format, y offset returned by 
`posn-at-point' is relative to the text area not including the header line.  
However, `posn-at-x-y' takes y offset relative to the buffer area including the 
header line.

Before Emacs 24, both of `posn-at-point' and `posn-at-x-y' are relative to the 
buffer area including the header line.
```

Original comment by `yukishi...@google.com` on 1 Nov 2013 at 3:06
- Changed state: **Started**

_Originally posted by @GoogleCodeExporter in https://github.com/google/mozc/issues/196#issuecomment-95066744_

Fix #713. Fix #965. Fix #1063. Close #1080.