### PR TITLE
Fix :global behavior with trailing slashes

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -1210,9 +1210,10 @@ This handler highlights the pattern of the current substitution."
 
 (defun evil-ex-parse-global (string)
   "Parse STRING as a global argument."
-  (let* ((args (evil-delimited-arguments string 2))
-         (pattern (nth 0 args))
-         (command (nth 1 args)))
+  (let* ((pattern (nth 0 (evil-delimited-arguments string 2)))
+         (command (and pattern
+                       (>= (- (length string) (length pattern)) 2)
+                       (substring string (+ (length pattern) 2)))))
     ;; use last pattern if none given
     (when (zerop (length pattern))
       (setq pattern

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7333,6 +7333,13 @@ maybe we need one line more with some text\n")
       "no 1\nno 2\nno x\nyes 4\nno x\nno x\n[n]o 7\n"
       ("u")
      "no 1\nno 2\nno [3]\nyes 4\nno 5\nno 6\nno 7\n"))
+  (ert-info ("global substitute with trailing slash")
+    (evil-test-buffer
+      "[n]o 1\nno 2\nno 3\nyes 4\nno 5\nno 6\nno 7\n"
+      (":g/no/s/[3-6]/x/" [return])
+      "no 1\nno 2\nno x\nyes 4\nno x\nno x\n[n]o 7\n"
+      ("u")
+      "no 1\nno 2\nno [3]\nyes 4\nno 5\nno 6\nno 7\n"))
   (evil-select-search-module 'evil-search-module 'evil-search)
   (ert-info ("global use last match if none given, with evil-search")
     (evil-test-buffer


### PR DESCRIPTION
`evil-delimited-arguments` might drop characters from the chained command string if the input ends with a trailing slash (so in something like `:g/pattern/s/pat/repl/`, the `/pat/repl/` part gets dropped). Since the chained command follows after the slash following the pattern, we can just take a substring instead of relying on `evil-delimited-arguments` for it.

Fixes #1165.