### PR TITLE
Teach more commands about evil-respect-visual-line-mode

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -660,7 +660,8 @@ Movement is restricted to the current line unless `evil-cross-lines' is non-nil.
     (let ((case-fold-search nil))
       (unless (prog1
                   (search-forward (char-to-string char)
-                                  (cond (evil-cross-lines)
+                                  (cond (evil-cross-lines
+                                         nil)
                                         ((and fwd visual)
                                          (save-excursion
                                            (end-of-visual-line)

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -652,16 +652,27 @@ Movement is restricted to the current line unless `evil-cross-lines' is non-nil.
   :type inclusive
   (interactive "<c><C>")
   (setq count (or count 1))
-  (let ((fwd (> count 0)))
+  (let ((fwd (> count 0))
+        (visual (and evil-respect-visual-line-mode
+                     visual-line-mode)))
     (setq evil-last-find (list #'evil-find-char char fwd))
     (when fwd (forward-char))
     (let ((case-fold-search nil))
       (unless (prog1
                   (search-forward (char-to-string char)
-                                  (unless evil-cross-lines
-                                    (if fwd
-                                        (line-end-position)
-                                      (line-beginning-position)))
+                                  (cond (evil-cross-lines)
+                                        ((and fwd visual)
+                                         (save-excursion
+                                           (end-of-visual-line)
+                                           (point)))
+                                        (fwd
+                                         (line-end-position))
+                                        (visual
+                                         (save-excursion
+                                           (beginning-of-visual-line)
+                                           (point)))
+                                        (t
+                                         (line-beginning-position)))
                                   t count)
                 (when fwd (backward-char)))
         (user-error "Can't find %c" char)))))
@@ -2354,7 +2365,16 @@ non nil it should be number > 0. The insertion will be repeated
 in the next VCOUNT - 1 lines below the current one."
   (interactive "p")
   (push (point) buffer-undo-list)
-  (back-to-indentation)
+  (if (and visual-line-mode
+           evil-respect-visual-line-mode)
+      (goto-char
+       (max (save-excursion
+              (back-to-indentation)
+              (point))
+            (save-excursion
+              (beginning-of-visual-line)
+              (point))))
+    (back-to-indentation))
   (setq evil-insert-count count
         evil-insert-lines nil
         evil-insert-vcount
@@ -2371,7 +2391,10 @@ The insertion will be repeated COUNT times.  If VCOUNT is non nil
 it should be number > 0. The insertion will be repeated in the
 next VCOUNT - 1 lines below the current one."
   (interactive "p")
-  (evil-move-end-of-line)
+  (if (and visual-line-mode
+           evil-respect-visual-line-mode)
+      (evil-end-of-visual-line)
+    (evil-move-end-of-line))
   (setq evil-insert-count count
         evil-insert-lines nil
         evil-insert-vcount

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -217,16 +217,22 @@ a line."
   :group 'evil)
 
 (defcustom evil-respect-visual-line-mode nil
-  "Whether to remap movement commands when `visual-line-mode' is active.
-This variable must be set before Evil is loaded. The commands
-swapped are
+  "Whether movement commands respect `visual-line-mode'.
+This variable must be set before Evil is loaded. When
+`visual-line-mode' is active, the following commands are swapped
 
 `evil-next-line'         <-> `evil-next-visual-line'
 `evil-previous-line'     <-> `evil-previous-visual-line'
 `evil-beginning-of-line' <-> `evil-beginning-of-visual-line'
-`evil-end-of-line'       <-> `evil-end-of-visual-line'"
+`evil-end-of-line'       <-> `evil-end-of-visual-line'
+
+The commands `evil-insert-line', `evil-append-line',
+`evil-find-char', `evil-find-char-backward', `evil-find-char-to'
+and `evil-find-char-to-backward' are also made aware of visual
+lines."
   :type 'boolean
   :group 'evil)
+
 
 (defcustom evil-repeat-find-to-skip-next t
   "Whether a repeat of t or T should skip an adjacent character."


### PR DESCRIPTION
The following commands now act on visual lines when
`evil-respect-visual-line-mode` is non-nil:

`evil-insert-line`
`evil-append-line`
`evil-find-char`
`evil-find-char-backward`
`evil-find-char-to`
`evil-find-char-to-backward`