### PR TITLE
Support more commands when visual-line-mode active

### DIFF
--- a/evil-macros.el
+++ b/evil-macros.el
@@ -557,8 +557,12 @@ RETURN-TYPE is non-nil."
             (let ((keys (nth 2 (evil-extract-count (this-command-keys)))))
               (setq keys (listify-key-sequence keys))
               (dotimes (var (length keys))
-                (define-key evil-operator-shortcut-map
-                  (vconcat (nthcdr var keys)) 'evil-line)))
+                (if (and evil-respect-visual-line-mode
+                         visual-line-mode)
+                    (define-key evil-operator-shortcut-map
+                      (vconcat (nthcdr var keys)) 'evil-screen-line)
+                  (define-key evil-operator-shortcut-map
+                    (vconcat (nthcdr var keys)) 'evil-line))))
             ;; read motion from keyboard
             (setq command (evil-read-motion motion)
                   motion (nth 0 command)

--- a/evil-states.el
+++ b/evil-states.el
@@ -258,6 +258,10 @@ the selection is enabled.
   "Linewise selection."
   :message "-- VISUAL LINE --")
 
+(evil-define-visual-selection screen-line
+  "Linewise selection in `visual-line-mode'."
+  :message "-- SCREEN LINE --")
+
 (evil-define-visual-selection block
   "Blockwise selection."
   :message "-- VISUAL BLOCK --"

--- a/evil-types.el
+++ b/evil-types.el
@@ -141,6 +141,31 @@ line and `evil-want-visual-char-semi-exclusive', then:
               (format "%s line%s" height
                       (if (= height 1) "" "s")))))
 
+(evil-define-type screen-line
+  "Include whole visual lines."
+  :one-to-one nil
+  :expand (lambda (beg end)
+            (evil-range
+             (progn
+               (goto-char beg)
+               (beginning-of-visual-line))
+             (progn
+               (goto-char end)
+               (save-excursion
+                 ;; `beginning-of-visual-line' reverts to the beginning of the
+                 ;; last visual line if the end of the last line is the end of
+                 ;; the buffer. This would prevent selecting the last screen
+                 ;; line.
+                 (if (= (line-beginning-position 2) (point-max))
+                     (point-max)
+                   (beginning-of-visual-line 2))))))
+  :contract (lambda (beg end)
+              (evil-range beg (max beg (1- end))))
+  :string (lambda (beg end)
+            (let ((height (count-screen-lines beg end)))
+              (format "%s visual line%s" height
+                      (if (= height 1) "" "s")))))
+
 (evil-define-type block
   "Like `inclusive', but for rectangles:
 the last column is included."

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -226,13 +226,29 @@ This variable must be set before Evil is loaded. When
 `evil-beginning-of-line' <-> `evil-beginning-of-visual-line'
 `evil-end-of-line'       <-> `evil-end-of-visual-line'
 
-The commands `evil-insert-line', `evil-append-line',
-`evil-find-char', `evil-find-char-backward', `evil-find-char-to'
-and `evil-find-char-to-backward' are also made aware of visual
-lines."
+These commands are remapped in `visual-line-mode'
+
+`evil-visual-line'        -> `evil-visual-screen-line'
+`evil-change-line'        -> `evil-change-visual-line'
+`evil-change-whole-line'  -> `evil-change-whole-visual-line'
+`evil-yank-line'          -> `evil-yank-visual-line'
+
+In addition, the following commands are made to act on visual
+lines (also called screen lines to avoid naming conflicts with
+visual state).
+
+`evil-insert-line'
+`evil-append-line'
+`evil-find-char'
+`evil-find-char-backward'
+`evil-find-char-to'
+`evil-find-char-to-backward'
+`evil-delete-line'
+
+Note that block selection is not aware of visual lines in
+`visual-line-mode'."
   :type 'boolean
   :group 'evil)
-
 
 (defcustom evil-repeat-find-to-skip-next t
   "Whether a repeat of t or T should skip an adjacent character."


### PR DESCRIPTION
Including, cc, dd, S, V, C, D, and Y.

This defines a new type, called a screen-line, which is named to
avoid conflicts with the existing evil-visual-line.