### PR TITLE
Make more commands support visual-line-mode

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1362,7 +1362,7 @@ or line COUNT to the top of the window."
       (cua-copy-region-to-global-mark beg end))
      ((eq type 'block)
       (evil-yank-rectangle beg end register yank-handler))
-     ((eq type 'line)
+     ((memq type '(line screen-line))
       (evil-yank-lines beg end register yank-handler))
      (t
       (evil-yank-characters beg end register yank-handler)))))

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -490,13 +490,31 @@ Based on `evil-enclose-ace-jump-for-motion'."
 
 ;; visual-line-mode integration
 (when evil-respect-visual-line-mode
-  (let ((swaps '((evil-next-line . evil-next-visual-line)
-                 (evil-previous-line . evil-previous-visual-line)
-                 (evil-beginning-of-line . evil-beginning-of-visual-line)
-                 (evil-end-of-line . evil-end-of-visual-line))))
-    (dolist (swap swaps)
-      (define-key visual-line-mode-map (vector 'remap (car swap)) (cdr swap))
-      (define-key visual-line-mode-map (vector 'remap (cdr swap)) (car swap)))))
+  (evil-define-command evil-digit-argument-or-beginning-of-visual-line ()
+    :digit-argument-redirection evil-beginning-of-visual-line
+    :keep-visual t
+    :repeat nil
+    (interactive)
+    (cond
+     (current-prefix-arg
+      (setq this-command #'digit-argument)
+      (call-interactively #'digit-argument))
+     (t
+      (let ((target (or (command-remapping #'evil-beginning-of-visual-line)
+                        #'evil-beginning-of-visual-line)))
+        (setq this-command 'evil-beginning-of-visual-line)
+        (call-interactively 'evil-beginning-of-visual-line)))))
+
+  (evil-define-minor-mode-key 'motion 'visual-line-mode
+    "j" 'evil-next-visual-line
+    "gj" 'evil-next-line
+    "k" 'evil-previous-visual-line
+    "gk" 'evil-previous-line
+    "0" 'evil-digit-argument-or-evil-beginning-of-visual-line
+    "g0" 'evil-beginning-of-line
+    "$" 'evil-end-of-visual-line
+    "g$" 'evil-end-of-line
+    "V" 'evil-visual-screen-line))
 
 ;;; abbrev.el
 (when evil-want-abbrev-expand-on-insert-exit

--- a/evil-macros.el
+++ b/evil-macros.el
@@ -558,7 +558,7 @@ RETURN-TYPE is non-nil."
               (setq keys (listify-key-sequence keys))
               (dotimes (var (length keys))
                 (define-key evil-operator-shortcut-map
-                  (vconcat (nthcdr var keys)) 'evil-line)))
+                  (vconcat (nthcdr var keys)) 'evil-line-or-visual-line)))
             ;; read motion from keyboard
             (setq command (evil-read-motion motion)
                   motion (nth 0 command)

--- a/evil-states.el
+++ b/evil-states.el
@@ -258,6 +258,10 @@ the selection is enabled.
   "Linewise selection."
   :message "-- VISUAL LINE --")
 
+(evil-define-visual-selection screen-line
+  "Linewise selection in `visual-line-mode'."
+  :message "-- SCREEN LINE --")
+
 (evil-define-visual-selection block
   "Blockwise selection."
   :message "-- VISUAL BLOCK --"

--- a/evil-types.el
+++ b/evil-types.el
@@ -141,6 +141,36 @@ line and `evil-want-visual-char-semi-exclusive', then:
               (format "%s line%s" height
                       (if (= height 1) "" "s")))))
 
+(evil-define-type screen-line
+  "Include whole lines, being aware of `visual-line-mode'
+when `evil-respect-visual-line-mode' is non-nil."
+  :one-to-one nil
+  :expand (lambda (beg end)
+            (if (or (not evil-respect-visual-line-mode)
+                    (not visual-line-mode))
+                (evil-line-expand beg end)
+              (evil-range
+               (progn
+                 (goto-char beg)
+                 (save-excursion
+                   (beginning-of-visual-line)))
+               (progn
+                 (goto-char end)
+                 (save-excursion
+                   ;; `beginning-of-visual-line' reverts to the beginning of the
+                   ;; last visual line if the end of the last line is the end of
+                   ;; the buffer. This would prevent selecting the last screen
+                   ;; line.
+                   (if (= (line-beginning-position 2) (point-max))
+                       (point-max)
+                     (beginning-of-visual-line 2)))))))
+  :contract (lambda (beg end)
+              (evil-range beg (max beg (1- end))))
+  :string (lambda (beg end)
+            (let ((height (count-screen-lines beg end)))
+              (format "%s screen line%s" height
+                      (if (= height 1) "" "s")))))
+
 (evil-define-type block
   "Like `inclusive', but for rectangles:
 the last column is included."

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -218,18 +218,7 @@ a line."
 
 (defcustom evil-respect-visual-line-mode nil
   "Whether movement commands respect `visual-line-mode'.
-This variable must be set before Evil is loaded. When
-`visual-line-mode' is active, the following commands are swapped
-
-`evil-next-line'         <-> `evil-next-visual-line'
-`evil-previous-line'     <-> `evil-previous-visual-line'
-`evil-beginning-of-line' <-> `evil-beginning-of-visual-line'
-`evil-end-of-line'       <-> `evil-end-of-visual-line'
-
-The commands `evil-insert-line', `evil-append-line',
-`evil-find-char', `evil-find-char-backward', `evil-find-char-to'
-and `evil-find-char-to-backward' are also made aware of visual
-lines."
+This variable must be set before Evil is loaded."
   :type 'boolean
   :group 'evil)
 
@@ -506,7 +495,9 @@ The default behavior is to yank the whole line."
   :set #'(lambda (sym value)
            (evil-add-command-properties
             'evil-yank-line
-            :motion (if value 'evil-end-of-line 'evil-line))))
+            :motion (if value
+                        'evil-end-of-line-or-visual-line
+                      'evil-line-or-visual-line))))
 
 (defcustom evil-disable-insert-state-bindings nil
   "Whether insert state bindings should be used. Excludes


### PR DESCRIPTION
when evil-respect-visual-line-mode is non-nil, including
evil-change-line, evil-delete-line, and evil-yank-line. Most of the work is done
through the motions evil-line-or-visual-line and
evil-end-of-line-or-visual-line. These motions use visual lines when
visual-line-mode and evil-respect-visual-line-mode are non-nil, and revert back
to standard lines otherwise.

Visual selection via visual lines in the sense of visual-line-mode is supported
by adding a new screen-line type (named to avoid confusion with visual state).