### PR TITLE
Unwed evil-move-beyond-eol and evil-move-cursor-back

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -83,8 +83,7 @@ of the line or the buffer; just return nil."
     (evil-motion-loop (nil (or count 1))
       (forward-char)
       ;; don't put the cursor on a newline
-      (when (and evil-move-cursor-back
-                 (not evil-move-beyond-eol)
+      (when (and (not evil-move-beyond-eol)
                  (not (evil-visual-state-p))
                  (not (evil-operator-state-p))
                  (eolp) (not (eobp)) (not (bolp)))
@@ -1607,7 +1606,6 @@ of the block."
     (when evil-this-motion
       (goto-char end)
       (when (and evil-cross-lines
-                 evil-move-cursor-back
                  (not evil-move-beyond-eol)
                  (not (evil-visual-state-p))
                  (not (evil-operator-state-p))

--- a/evil-common.el
+++ b/evil-common.el
@@ -973,10 +973,9 @@ Like `move-end-of-line', but retains the goal column."
     (move-end-of-line arg)
     (end-of-line)))
 
-(defun evil-adjust-cursor (&optional force)
+(defun evil-adjust-cursor (&optional _)
   "Move point one character back if at the end of a non-empty line.
-This behavior is contingent on the variable `evil-move-cursor-back';
-use the FORCE parameter to override it."
+This behavior is controled by `evil-move-beyond-eol'."
   (when (and (eolp)
              (not evil-move-beyond-eol)
              (not (bolp))
@@ -984,7 +983,7 @@ use the FORCE parameter to override it."
                 (save-excursion
                   (evil-move-end-of-line)
                   (point))))
-    (evil-move-cursor-back force)))
+    (evil-move-cursor-back t)))
 
 (defun evil-move-cursor-back (&optional force)
   "Move point one character back within the current line.

--- a/evil-common.el
+++ b/evil-common.el
@@ -1127,13 +1127,13 @@ This function should be used in forward motions. If `point' is close
 to eob so that no further forward motion is possible the error
 'end-of-buffer is raised. This is the case if `point' is at
 `point-max' or if is one position before `point-max',
-`evil-move-cursor-back' is non-nil and `point' is not at the end
+`evil-move-beyond-eol' is nil and `point' is not at the end
 of a line. The latter is necessary because `point' cannot be
-moved to `point-max' if `evil-move-cursor-back' is non-nil and
+moved to `point-max' if `evil-move-beyond-eol' is nil and
 the last line in the buffer is not empty."
   (when (or (eobp)
             (and (not (eolp))
-                 evil-move-cursor-back
+                 (not evil-move-beyond-eol)
                  (save-excursion (forward-char) (eobp))))
     (signal 'end-of-buffer nil)))
 

--- a/evil-macros.el
+++ b/evil-macros.el
@@ -168,8 +168,7 @@ upon reaching the beginning or end of the current line.
      (when (save-excursion (goto-char end) (bolp))
        (setq end (max beg (1- end))))
      ;; don't include the newline in Normal state
-     (when (and evil-move-cursor-back
-                (not evil-move-beyond-eol)
+     (when (and (not evil-move-beyond-eol)
                 (not (evil-visual-state-p))
                 (not (evil-operator-state-p)))
        (setq end (max beg (1- end))))

--- a/evil-macros.el
+++ b/evil-macros.el
@@ -295,7 +295,7 @@ of the object; otherwise it is placed at the end of the object."
             (unless (bobp) (backward-char)))
           (when (or (evil-normal-state-p)
                     (evil-motion-state-p))
-            (evil-adjust-cursor t)))))
+            (evil-adjust-cursor)))))
      ((> count 0)
       (when (evil-eobp)
         (signal 'end-of-buffer nil))
@@ -310,7 +310,7 @@ of the object; otherwise it is placed at the end of the object."
             (unless (bobp) (backward-char)))
           (when (or (evil-normal-state-p)
                     (evil-motion-state-p))
-            (evil-adjust-cursor t)))))
+            (evil-adjust-cursor)))))
      (t
       count))))
 

--- a/evil-search.el
+++ b/evil-search.el
@@ -774,7 +774,7 @@ the direcion is determined by `evil-ex-search-direction'."
       (when (eq evil-ex-search-direction 'forward)
         (unless (eobp) (forward-char))
         ;; maybe skip end-of-line
-        (when (and evil-move-cursor-back (eolp) (not (eobp)))
+        (when (and (not evil-move-beyond-eol) (eolp) (not (eobp)))
           (forward-char)))
       (let ((res (evil-ex-find-next nil nil (not evil-search-wrap))))
         (cond

--- a/evil-states.el
+++ b/evil-states.el
@@ -128,10 +128,10 @@ commands opening a new line."
     (evil-set-marker ?^ nil t)
     (unless (eq evil-want-fine-undo t)
       (evil-end-undo-step))
-    (when evil-move-cursor-back
-      (when (or (evil-normal-state-p evil-next-state)
-                (evil-motion-state-p evil-next-state))
-        (evil-move-cursor-back))))))
+    (when (or (evil-normal-state-p evil-next-state)
+              (evil-motion-state-p evil-next-state))
+      (evil-move-cursor-back
+       (and (eolp) (not evil-move-beyond-eol)))))))
 
 (defun evil-insert-repeat-hook ()
   "Record insertion keys in `evil-insert-repeat-info'."
@@ -856,8 +856,7 @@ CORNER defaults to `upper-left'."
     (remove-hook 'pre-command-hook #'evil-replace-pre-command t)
     (unless (eq evil-want-fine-undo t)
       (evil-end-undo-step))
-    (when evil-move-cursor-back
-      (evil-move-cursor-back))))
+    (evil-move-cursor-back)))
   (setq evil-replace-alist nil))
 
 (defun evil-replace-pre-command ()

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2694,7 +2694,7 @@ This bufferThis bufferThis buffe[r];; and for Lisp evaluation."))
       ";[;] This buffer is for notes."))
   (ert-info ("End of line")
     (let ((evil-cross-lines t)
-          (evil-move-cursor-back t))
+          (evil-move-beyond-eol nil))
       (evil-test-buffer
         ";; This buffer is for notes[,]
 ;; and for Lisp evaluation."


### PR DESCRIPTION
The docstring of evil-cursor-back only mentions that it applies to moving the
cursor back when exiting insert state, but in many cases it was tied to also
moving the cursor when reaching the end of the line. We have
evil-move-beyond-eol to control that behavior, and there doesn't seem to be a
good reason that the two must be tied together.

Fixes #1178