### PR TITLE
Delete window on q if created to hold evil-list-view-mode buffer

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3845,7 +3845,7 @@ should be left-aligned for left justification."
            (entry (elt tabulated-list-entries (1- line))))
       (funcall evil-list-view-select-action (nth 1 entry)))))
 
-(define-key evil-list-view-mode-map (kbd "q") #'kill-this-buffer)
+(define-key evil-list-view-mode-map (kbd "q") #'quit-window)
 (define-key evil-list-view-mode-map [follow-link] nil) ;; allows mouse-1 to be activated
 (define-key evil-list-view-mode-map [mouse-1] #'evil-list-view-goto-entry)
 (define-key evil-list-view-mode-map [return] #'evil-list-view-goto-entry)


### PR DESCRIPTION
Windows created specifically to hold evil-list-view-mode buffers seem a lot like
other temporary windows in Emacs, e.g. the ones created by describe-function.

These tend to define q to mean quit-window, rather than kill-this-buffer; The
quit-window command has the nice property that if a window was created to hold
the buffer in question, that window will be deleted – but if an existing window
was repurposed to hold the buffer, the effect is the same as bury-buffer.

Note that this is also in line with the default behaviour of Vim, where pressing
q in the marks list restores the previous window layout.