### PR TITLE
Fix evil-get-marker switching buffers

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1952,8 +1952,9 @@ or a marker object pointing nowhere."
         (when (and (symbolp marker) (boundp marker))
           (setq marker (symbol-value marker)))
         (when (functionp marker)
-          (funcall marker)
-          (setq marker (point)))
+          (save-window-excursion
+            (funcall marker)
+            (setq marker (move-marker (make-marker) (point)))))
         (when (markerp marker)
           (if (eq (marker-buffer marker) (current-buffer))
               (setq marker (marker-position marker))


### PR DESCRIPTION
At the moment, if the last jump marks are in a different buffer, then calling ``(evil-get-marker ?`)`` or `(evil-get-marker ?')` will switch the current buffer. This PR adds a `save-window-excursion` call to fix that.

You can reproduce the behavior by doing the following:
- Run `make emacs`.
- Jump to the top of the scratch buffer with `gg`.
- Switch to the messages buffer with `C-x b *Messages* [RET]`.
- Evaluate `(evil-get-marker ?')` with `M-:`. The buffer should change.