### PR TITLE
Redo travis setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 *.vrs
 .depend
 evil-autoloads.el
+test-results.txt
+typescript

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,29 @@
-language: generic
-sudo: true
+language: nix
+
+os:
+  - linux
 
 env:
-  global:
-    - CURL="curl -fsSkL --retry 9 --retry-delay 9"
-  matrix:
-  - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.3
-  - EMACS_VERSION=26.3
-  - EMACS_VERSION=master
+  - EMACS_CI=emacs-24-5
+  - EMACS_CI=emacs-25-3
+  - EMACS_CI=emacs-26-3
+  - EMACS_CI=emacs-snapshot
 
 matrix:
   allow_failures:
-    - env: EMACS_VERSION=master
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y aspell aspell-en # required for flyspell test
+    - env: EMACS_CI=emacs-snapshot
 
 install:
-  - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
-  - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
-  - export EMACS=/tmp/emacs/bin/emacs
+  - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
 
 script:
-  - $EMACS --version
-  - emacs=$EMACS make test
+  - emacs --version
+  - script -eqc 'make test' > /dev/null
+
+after_script:
+  - cat test-results.txt
 
 notifications:
   email:
-    # Default is change, but that includes a new branch's 1st success.
     on_success: never
-    on_failure: never
+    on_failure: always

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -5147,6 +5147,7 @@ Below some empty line."))
 (ert-deftest evil-test-flyspell-motions ()
   "Test flyspell motions"
   :tags '(evil motion)
+  (skip-unless (executable-find "aspell"))
   (ert-info ("Simple")
     (evil-test-buffer
       "[I] cannt tpye for lyfe"


### PR DESCRIPTION
It's not been a very well kept secret that CI has been absolutely useless. Hopefully this fixes most of the issues.

The main reason for the problems is that we've been using `ert-run-tests-batch-and-exit`, which apparently in Emacs 26 and later raises an error outside of batch mode. This just leaves the test scripts for those versions to hang for ever, waiting for Emacs to exit.

We'd prefer not to use batch mode because we have tests that use Emacs functionality not available there (like windows).

Instead I've modified the test script to mimic the behaviour of batch mode, to run the tests interactively instead and then exit emacs with an appropriate return code.

Since the test results are very difficult to read in the travis log, I've instead chosen to hide them entirely by wrapping the tests in a `script` invocation redirected to `/dev/null`, which should fool Emacs into thinking it's running in a TTY. The ERT buffer contents are then written to a file that is later catted to the log.

I took the liberty of using Purcell's Emacs installation for Travis based on nix, which seemed somewhat cleaner than what we had been using. I couldn't figure out how to install aspell there (well I could, but I couldn't figure out how to make it find the dictionary), so that test is skipped currently.