### PR TITLE
Fix for void variable user-error - run-hook-with-args-until-success: Symbol’s value as variable is void: user-error `

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2735,8 +2735,7 @@ The search is unbounded, i.e., the pattern is not wrapped in
     (let ((identifier (save-excursion
                         (goto-char position)
                         (xref-backend-identifier-at-point (xref-find-backend)))))
-      (ignore-error user-error
-        (xref-find-definitions identifier)))))
+      (ignore-errors (xref-find-definitions identifier)))))
 
 (defun evil-goto-definition-search (string _position)
   "Find definition for STRING with evil-search."


### PR DESCRIPTION
Getting error in Evil package  MELPA (build# 20191125.1525) or Checkout from Github `master` branch (`56eb22ac71f10a5475945086ebb9ed45af0a6638`) 

Steps to reproduce:
- While in `evil-normal-state`, goto a symbol definition by typing `gd`  ( bound to `evil-goto-definition` by default)
- Getting error `run-hook-with-args-until-success: Symbol’s value as variable is void: user-error
`
Fix:
This patch addresses void variable - `user-error`