### PR TITLE
Filter bad register names

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2143,12 +2143,15 @@ register instead of replacing its content."
     (set-register register text))))
 
 (defun evil-register-list ()
-  "Returns an alist of all registers"
+  "Returns an alist of all registers, but only those named
+with number or character. Registers with symbol or string in names are ignored
+to keep Vim compatibility with register jumps."
   (sort (append (mapcar #'(lambda (reg)
                             (cons reg (evil-get-register reg t)))
                         '(?\" ?* ?+ ?% ?# ?/ ?: ?. ?-
                               ?1 ?2 ?3 ?4 ?5 ?6 ?7 ?8 ?9))
-                register-alist nil)
+                (cl-remove-if-not (lambda (x) (number-or-marker-p x)) register-alist)
+                nil)
         #'(lambda (reg1 reg2) (< (car reg1) (car reg2)))))
 
 (defsubst evil-kbd-macro-suppress-motion-error ()

--- a/evil-common.el
+++ b/evil-common.el
@@ -28,6 +28,7 @@
 (require 'evil-digraphs)
 (require 'rect)
 (require 'thingatpt)
+(require 'cl-lib)
 
 ;;; Code:
 
@@ -2150,7 +2151,7 @@ to keep Vim compatibility with register jumps."
                             (cons reg (evil-get-register reg t)))
                         '(?\" ?* ?+ ?% ?# ?/ ?: ?. ?-
                               ?1 ?2 ?3 ?4 ?5 ?6 ?7 ?8 ?9))
-                (cl-remove-if-not #'(lambda (reg) (number-or-marker-p reg)) register-alist)
+                (cl-remove-if-not #'number-or-marker-p register-alist)
                 nil)
         #'(lambda (reg1 reg2) (< (car reg1) (car reg2)))))
 

--- a/evil-common.el
+++ b/evil-common.el
@@ -2150,7 +2150,7 @@ to keep Vim compatibility with register jumps."
                             (cons reg (evil-get-register reg t)))
                         '(?\" ?* ?+ ?% ?# ?/ ?: ?. ?-
                               ?1 ?2 ?3 ?4 ?5 ?6 ?7 ?8 ?9))
-                (cl-remove-if-not (lambda (x) (number-or-marker-p x)) register-alist)
+                (cl-remove-if-not #'(lambda (reg) (number-or-marker-p reg)) register-alist)
                 nil)
         #'(lambda (reg1 reg2) (< (car reg1) (car reg2)))))
 


### PR DESCRIPTION
Some modes, like fzf.el, will put :fzf-windows as register name,
causing Evil :register command to fail. This command, but also Vim,
expects registers to be named with number or character.

This is not much fault of fzf.el mode (or similar modes), because
Emacs keeps both window configuration and marks in a single
"register-alist" and mode developers are free to use whetever name for
restoring window configurations.

This commit fixes it by filtering out all register names not conforming to
proper Vim-like naming schema.