### PR TITLE
Release 1.12.16 (Oops)

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,4 +1,4 @@
-(package "evil" "1.2.16" "Extensible Vi layer for Emacs.")
+(package "evil" "1.12.16" "Extensible Vi layer for Emacs.")
 
 (files "*.el")
 

--- a/evil-command-window.el
+++ b/evil-command-window.el
@@ -2,7 +2,7 @@
 ;; Author: Emanuel Evans <emanuel.evans at gmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2,7 +2,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-common.el
+++ b/evil-common.el
@@ -2,7 +2,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-core.el
+++ b/evil-core.el
@@ -2,7 +2,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-development.el
+++ b/evil-development.el
@@ -2,7 +2,7 @@
 
 ;; Author: Justin Burkett <justin at burkett dot cc>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-digraphs.el
+++ b/evil-digraphs.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -3,7 +3,7 @@
 ;; Author: Frank Fischer <frank fischer at mathematik.tu-chemnitz.de>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -2,7 +2,7 @@
 
 ;; Author: Bailey Ling <bling at live.ca>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-keybindings.el
+++ b/evil-keybindings.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-macros.el
+++ b/evil-macros.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-pkg.el
+++ b/evil-pkg.el
@@ -1,6 +1,6 @@
 (define-package
   "evil"
-  "1.2.16"
+  "1.12.16"
   "Extensible Vi layer for Emacs."
   '((emacs "24.1")
     (undo-tree "0.6.3")

--- a/evil-repeat.el
+++ b/evil-repeat.el
@@ -3,7 +3,7 @@
 ;; Author: Frank Fischer <frank.fischer at mathematik.tu-chemnitz.de>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-search.el
+++ b/evil-search.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-states.el
+++ b/evil-states.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -2,8 +2,8 @@
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
-;; Package-Requires: ((evil "1.2.16"))
-;; Version: 1.2.16
+;; Package-Requires: ((evil "1.12.16"))
+;; Version: 1.12.16
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-types.el
+++ b/evil-types.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -3,7 +3,7 @@
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 
-;; Version: 1.2.16
+;; Version: 1.12.16
 
 ;;
 ;; This file is NOT part of GNU Emacs.
@@ -1875,7 +1875,7 @@ Otherwise the previous command is assumed as substitute.")
                       (buffer-substring (point-min)
                                         (line-end-position))))
           ;; no repo, use plain version
-          "1.2.16"))))
+          "1.12.16"))))
   "The current version of Evil")
 
 (defcustom evil-want-integration t

--- a/evil.el
+++ b/evil.el
@@ -55,7 +55,7 @@
 ;;      To get in touch, please use the bug tracker or the
 ;;      mailing list (see below).
 ;; Created: 2011-03-01
-;; Version: 1.2.16
+;; Version: 1.12.16
 ;; Keywords: emulation, vim
 ;; URL: https://github.com/emacs-evil/evil
 ;;      Repository: https://github.com/emacs-evil/evil.git


### PR DESCRIPTION
1.2.15 was accidentally tagged as 1.12.15, which was picked up and released by MELPA Stable.  So to be able to release new stable versions I guess it's easiest to just say that we're on 1.12 now.