### PR TITLE
Fix bounds of wrapped search

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -191,10 +191,16 @@ of the buffer."
            result)
        (setq result (funcall search-fun string bound
                              ,(if wrap t 'noerror) count))
-       (when (and ,wrap (null result))
+       ;; Wrap the search only if a result was not found, and a bound not set
+       (when (and ,wrap (null result) (null bound))
          (goto-char ,(if forward '(point-min) '(point-max)))
          (unwind-protect
-             (setq result (funcall search-fun string bound noerror count))
+             ;; The wrapped search is bounded by the original starting point
+             (setq result (funcall search-fun string
+                                   ,(if forward
+                                        '(max (point-min) (1- start))
+                                      '(min (point-max) (1+ start)))
+                                   noerror count))
            (unless result
              (goto-char start))))
        result)))


### PR DESCRIPTION
Do not perform the second search if the original search bound was set, as it must necessarily be bypassed.

Use the original starting point for the search as the bound for the second search.

Fixes #843 and supersedes #1070.