### PR TITLE
Expand abbrevs after insert state only if abbrev-mode is enabled

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -516,9 +516,12 @@ Based on `evil-enclose-ace-jump-for-motion'."
     "V" 'evil-visual-screen-line))
 
 ;;; abbrev.el
-(when evil-want-abbrev-expand-on-insert-exit
-  (eval-after-load 'abbrev
-    '(add-hook 'evil-insert-state-exit-hook 'expand-abbrev)))
+(defun evil-maybe-expand-abbrev ()
+  (when (and abbrev-mode evil-want-abbrev-expand-on-insert-exit)
+    (expand-abbrev)))
+
+(eval-after-load 'abbrev
+  '(add-hook 'evil-insert-state-exit-hook 'evil-maybe-expand-abbrev))
 
 ;;; ElDoc
 (eval-after-load 'eldoc

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8262,20 +8262,30 @@ maybe we need one line more with some text\n")
   :tags '(evil abbrev)
   (ert-info ("Test abbrev expansion on insert state exit")
     (define-abbrev-table 'global-abbrev-table
-      '(("undef" "undefined"))) ;; add global abbrev
+      '(("undef" "undefined")))         ; add global abbrev
+    (evil-test-buffer
+      "foo unde[f] bar"
+      (abbrev-mode)
+      ("a" [escape])
+      "foo undefine[d] bar")            ; 'undef' should be expanded
     (evil-test-buffer
       "foo unde[f] bar"
       ("a" [escape])
-      "foo undefine[d] bar") ;; 'undef' should be expanded
+      "foo unde[f] bar")                ; 'undef' shouldn't be expanded,
+                                        ; abbrev-mode is not enabled
     (evil-test-buffer
       "fo[o] undef bar"
+      (abbrev-mode)
       ("a" [escape])
-      "fo[o] undef bar") ;; 'foo' shouldn't be expanded, it's not an abbrev
-    (kill-all-abbrevs) ;; remove abbrevs
+      "fo[o] undef bar")                ; 'foo' shouldn't be expanded,
+                                        ; it's not an abbrev
+    (kill-all-abbrevs)                  ; remove all abbrevs
     (evil-test-buffer
       "foo unde[f] bar"
+      (abbrev-mode)
       ("a" [escape])
-      "foo unde[f] bar") ;; 'undef' is not an abbrev, shouldn't be expanded
+      "foo unde[f] bar")                ; 'undef' shouldn't be expanded,
+                                        ; it's not an abbrev
     (setq abbrevs-changed nil)))
 
 (ert-deftest evil-test-text-object-macro ()

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1232,8 +1232,8 @@ command is non-zero."
   :group 'evil)
 
 (defcustom evil-want-abbrev-expand-on-insert-exit t
-  "If non-nil abbrevs will be expanded when leaving Insert state
-like in Vim. This variable is read only on load."
+  "If non-nil abbrevs will be expanded when leaving insert state
+like in Vim, if `abbrev-mode' is on."
   :type 'boolean
   :group 'evil)
 


### PR DESCRIPTION
If `evil-want-abbrev-expand-on-insert-exit` is non-nil, abbrevs are always expanded when exiting insert state, regardless of whether `abbrev-mode` is enabled. This respects the setting of `abbrev-mode`, and also allows setting the variable post-load or buffer-locally.

Fixes #1175 