### PR TITLE
Remove some emacs state modes

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -713,7 +713,6 @@ expression matching the buffer's name and STATE is one of `normal',
     gdb-registers-mode
     gdb-threads-mode
     gist-list-mode
-    git-commit-mode
     git-rebase-mode
     gnus-article-mode
     gnus-browse-mode

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -737,14 +737,6 @@ expression matching the buffer's name and STATE is one of `normal',
     magit-stash-mode
     magit-stashes-mode
     magit-status-mode
-    ;; Obsolete as of Magit v2.1.0
-    magit-mode
-    magit-branch-manager-mode
-    magit-commit-mode
-    magit-key-mode
-    magit-rebase-mode
-    magit-wazzup-mode
-    ;; end obsolete
     mh-folder-mode
     monky-mode
     mpuz-mode


### PR DESCRIPTION
- Remove some obsolete modes from default Emacs state
- Don't start `git-commit-mode` in Emacs state (see discussion in #1145, evil-magit sets it to the default state so this feels like a sensible default)

cc @justbur

Fix #1145