### PR TITLE
Fix behavior of evil-scroll-up and evil-scroll-down again

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -868,6 +868,19 @@ Inhibits echo area messages, mode line updates and cursor changes."
   `(let ((evil-no-display t))
      ,@body))
 
+(defvar evil-cached-header-line-height nil
+  "Cached height of the header line.")
+
+(defun evil-header-line-height ()
+  "Return the height of the header line.
+If there is no header line, return 0."
+  (if (fboundp 'window-header-line-height)
+      (window-header-line-height)
+      (let ((posn (posn-at-x-y 0 0)))
+        (or (when (eq (posn-area posn) 'header-line)
+              (cdr (posn-object-width-height posn)))
+            0))))
+
 (defun evil-posn-x-y (position)
   "Return the x and y coordinates in POSITION.
 This function returns y offset from the top of the buffer area including
@@ -882,7 +895,9 @@ to GNU Emacs team.  This function fixes the asymmetry between them.
 Learned from mozc.el."
   (let ((xy (posn-x-y position)))
     (when header-line-format
-      (setcdr xy (+ (cdr xy) (window-header-line-height))))
+      (setcdr xy (+ (cdr xy)
+                    (or evil-cached-header-line-height
+                        (setq evil-cached-header-line-height (evil-header-line-height))))))
     xy))
 
 (defun evil-count-lines (beg end)

--- a/evil-common.el
+++ b/evil-common.el
@@ -868,16 +868,6 @@ Inhibits echo area messages, mode line updates and cursor changes."
   `(let ((evil-no-display t))
      ,@body))
 
-(defvar evil-cached-header-line-height nil
-  "Cached height of the header line.")
-
-(defun evil-header-line-height ()
-  "Return the height of the header line.
-If there is no header line, return nil."
-  (let ((posn (posn-at-x-y 0 0)))
-    (when (eq (posn-area posn) 'header-line)
-      (cdr (posn-object-width-height posn)))))
-
 (defun evil-posn-x-y (position)
   "Return the x and y coordinates in POSITION.
 This function returns y offset from the top of the buffer area including
@@ -892,10 +882,7 @@ to GNU Emacs team.  This function fixes the asymmetry between them.
 Learned from mozc.el."
   (let ((xy (posn-x-y position)))
     (when header-line-format
-      (setcdr xy (+ (cdr xy)
-                    (or evil-cached-header-line-height
-                        (setq evil-cached-header-line-height (evil-header-line-height))
-                        0))))
+      (setcdr xy (+ (cdr xy) (window-header-line-height))))
     xy))
 
 (defun evil-count-lines (beg end)


### PR DESCRIPTION
The PR #1154 is supposed to fix the issue about evil-scroll-up
and evil-scroll-down. It works nicely in most scenarios.
However, when the header line is really tall,
evil-header-line-height will give an incorrect result,
making the bug that is supposed to be fixed by the mentioned PR
reappear again.

This PR switches evil-header-line-height to Emacs' built-in
window-header-line-height which corrects the mistake.