### PR TITLE
Implement Vim Ctrl-f in minibuffer.

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -222,6 +222,24 @@ Otherwise behaves like `delete-backward-char'."
   (unless (minibufferp)
     (abort-recursive-edit)))
 
+(defun evil-ex-command-window ()
+  "Start command window with ex history and current minibuffer content."
+  (interactive)
+  (let ((current (minibuffer-contents))
+		  (config  (current-window-configuration)))
+	  (evil-ex-teardown)
+	  (select-window (minibuffer-selected-window) t)
+	  (evil-command-window (cons current evil-ex-history)
+						             ":"
+						             (apply-partially 'evil-ex-command-window-execute config))))
+
+(defun evil-ex-command-window-execute (config result)
+  (select-window (active-minibuffer-window) t)
+  (set-window-configuration config)
+  (delete-minibuffer-contents)
+  (insert result)
+  (exit-minibuffer))
+
 (defun evil-ex-setup ()
   "Initialize Ex minibuffer.
 This function registers several hooks that are used for the

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -226,12 +226,12 @@ Otherwise behaves like `delete-backward-char'."
   "Start command window with ex history and current minibuffer content."
   (interactive)
   (let ((current (minibuffer-contents))
-		  (config  (current-window-configuration)))
-	  (evil-ex-teardown)
-	  (select-window (minibuffer-selected-window) t)
-	  (evil-command-window (cons current evil-ex-history)
-						             ":"
-						             (apply-partially 'evil-ex-command-window-execute config))))
+        (config (current-window-configuration)))
+    (evil-ex-teardown)
+    (select-window (minibuffer-selected-window) t)
+    (evil-command-window (cons current evil-ex-history)
+                         ":"
+                         (apply-partially 'evil-ex-command-window-execute config))))
 
 (defun evil-ex-command-window-execute (config result)
   (select-window (active-minibuffer-window) t)

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -522,6 +522,7 @@ included in `evil-insert-state-bindings' by default."
 
 ;; search command line
 (define-key evil-ex-search-keymap "\d" #'evil-ex-delete-backward-char)
+(define-key evil-ex-search-keymap "\C-f" 'evil-ex-search-command-window)
 (define-key evil-ex-search-keymap "\C-r" 'evil-paste-from-register)
 (define-key evil-ex-search-keymap "\C-n" 'next-history-element)
 (define-key evil-ex-search-keymap "\C-p" 'previous-history-element)
@@ -535,6 +536,7 @@ included in `evil-insert-state-bindings' by default."
 (define-key evil-ex-completion-map "\C-b" 'move-beginning-of-line)
 (define-key evil-ex-completion-map "\C-c" 'abort-recursive-edit)
 (define-key evil-ex-completion-map "\C-d" 'evil-ex-completion)
+(define-key evil-ex-completion-map "\C-f" 'evil-ex-command-window)
 (define-key evil-ex-completion-map "\C-g" 'abort-recursive-edit)
 (define-key evil-ex-completion-map "\C-k" 'evil-insert-digraph)
 (define-key evil-ex-completion-map "\C-l" 'evil-ex-completion)

--- a/evil-search.el
+++ b/evil-search.el
@@ -1047,11 +1047,11 @@ any error conditions."
   "Start command window with search history and current minibuffer content."
   (interactive)
   (let ((current (minibuffer-contents))
-		    (config  (current-window-configuration)))
-	  (select-window (minibuffer-selected-window) t)
-	  (evil-command-window (cons current evil-ex-search-history)
-						             (evil-search-prompt (eq evil-ex-search-direction 'forward))
-						             (apply-partially 'evil-ex-command-window-execute config))))
+        (config (current-window-configuration)))
+    (select-window (minibuffer-selected-window) t)
+    (evil-command-window (cons current evil-ex-search-history)
+                         (evil-search-prompt (eq evil-ex-search-direction 'forward))
+                         (apply-partially 'evil-ex-command-window-execute config))))
 
 (defun evil-ex-search-goto-offset (offset)
   "Move point according to search OFFSET and set `evil-this-type' accordingly.

--- a/evil-search.el
+++ b/evil-search.el
@@ -1043,6 +1043,16 @@ any error conditions."
   (evil-ex-delete-hl 'evil-ex-search)
   (abort-recursive-edit))
 
+(defun evil-ex-search-command-window ()
+  "Start command window with search history and current minibuffer content."
+  (interactive)
+  (let ((current (minibuffer-contents))
+		    (config  (current-window-configuration)))
+	  (select-window (minibuffer-selected-window) t)
+	  (evil-command-window (cons current evil-ex-search-history)
+						             (evil-search-prompt (eq evil-ex-search-direction 'forward))
+						             (apply-partially 'evil-ex-command-window-execute config))))
+
 (defun evil-ex-search-goto-offset (offset)
   "Move point according to search OFFSET and set `evil-this-type' accordingly.
 This function assumes that the current match data represents the


### PR DESCRIPTION
Open apropriate command windows for Ctrl-f while in minibuffer for an ex command
or a search. As all ways to abort a minibuffer do not return and restore the
active buffer, we have to set the content of the minibuffer and exit normally to
trigger the apropriate action. Also restoring the window configuration is
necessary so minibuffer-selected-window is not changed.

This pull request should resolve issue #1147