### PR TITLE
Preserve the tab-bar in `evil-read-key'

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -556,6 +556,8 @@ Translates it according to the input method."
             (progn
               (define-key new-global-map [menu-bar]
                 (lookup-key global-map [menu-bar]))
+              (define-key new-global-map [tab-bar]
+                (lookup-key global-map [tab-bar]))
               (define-key new-global-map [tool-bar]
                 (lookup-key global-map [tool-bar]))
               (add-to-list 'new-global-map


### PR DESCRIPTION
When setting a new global map, the tab-bar entry must be copied to the new map from the old one to avoid hiding the tab bar.

Fixes #1245.

* `evil-common.el` (`evil-read-key`): Preserve the `tab-bar` entry from the old global map.