### PR TITLE
Call delete-backward-char interactively again

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1479,7 +1479,7 @@ be joined with the previous line if and only if
 `evil-backspace-join-lines'."
   (interactive "p")
   (if (or evil-backspace-join-lines (not (bolp)))
-      (delete-char -1)
+      (call-interactively 'delete-backward-char)
     (user-error "Beginning of line")))
 
 (evil-define-command evil-delete-backward-word ()

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -1943,7 +1943,7 @@ ine3 line3      line3 l\n")))
       "abc def\n   ghi j[k]l\n"
       ("i" (call-interactively #'evil-delete-back-to-indentation))
       "abc def\n   [k]l\n"
-      (execute-kbd-macro (concat (kbd "C-o") "2h"))
+      (left-char 2)
       "abc def\n [ ] kl\n"
       (call-interactively #'evil-delete-back-to-indentation)
       "abc def\n[ ] kl\n"
@@ -1953,8 +1953,9 @@ ine3 line3      line3 l\n")))
     (evil-test-buffer
       "abc def\n[k]l\n"
       (should-error
-       (progn (execute-kbd-macro "i")
-              (call-interactively #'evil-delete-back-to-indentation)))
+       (progn
+         (execute-kbd-macro "i")
+         (call-interactively #'evil-delete-back-to-indentation)))
       "abc def\n[k]l\n")))
 
 (ert-deftest evil-test-change ()


### PR DESCRIPTION
Reverts part of 1d6ba80.

Fixes #1253.