### PR TITLE
Enable lexical binding

### DIFF
--- a/evil-command-window.el
+++ b/evil-command-window.el
@@ -1,4 +1,4 @@
-;;; evil-command-window.el --- Evil command line window implementation
+;;; evil-command-window.el --- Evil command line window implementation -*- lexical-binding: t -*-
 ;; Author: Emanuel Evans <emanuel.evans at gmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1,4 +1,4 @@
-;;; evil-commands.el --- Evil commands and operators
+;;; evil-commands.el --- Evil commands and operators -*- lexical-binding: t -*-
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 

--- a/evil-common.el
+++ b/evil-common.el
@@ -1,4 +1,4 @@
-;;; evil-common.el --- Common functions and utilities
+;;; evil-common.el --- Common functions and utilities -*- lexical-binding: t -*-
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 

--- a/evil-core.el
+++ b/evil-core.el
@@ -1,4 +1,4 @@
-;;; evil-core.el --- Core functionality
+;;; evil-core.el --- Core functionality -*- lexical-binding: t -*-
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
 

--- a/evil-development.el
+++ b/evil-development.el
@@ -1,4 +1,4 @@
-;;; evil-development.el --- Useful features for Evil developers
+;;; evil-development.el --- Useful features for Evil developers -*- lexical-binding: t -*-
 
 ;; Author: Justin Burkett <justin at burkett dot cc>
 

--- a/evil-digraphs.el
+++ b/evil-digraphs.el
@@ -1,4 +1,4 @@
-;;; evil-digraphs.el --- Digraphs
+;;; evil-digraphs.el --- Digraphs -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -1,4 +1,4 @@
-;;; evil-ex.el --- Ex-mode
+;;; evil-ex.el --- Ex-mode -*- lexical-binding: nil -*-
 
 ;; Author: Frank Fischer <frank fischer at mathematik.tu-chemnitz.de>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>
@@ -905,6 +905,33 @@ POS defaults to the current position of point."
     (when contexts
       (nth pos contexts))))
 
+(defun evil-parser--dexp (obj)
+  "Parse a numerical dollar-sign symbol.
+Given e.g. $4, return 4."
+  (when (symbolp obj)
+    (let ((str (symbol-name obj)))
+      (save-match-data
+        (when (string-match "\\$\\([0-9]+\\)" str)
+          (string-to-number (match-string 1 str)))))))
+
+(defun evil-parser--dval (obj result)
+  "Substitute all dollar-sign symbols in OBJ.
+Each dollar-sign symbol is replaced with the corresponding
+element in RESULT, so that $1 becomes the first element, etc.
+The special value $0 is substituted with the whole list RESULT.
+If RESULT is not a list, all dollar-sign symbols are substituted with
+RESULT."
+  (if (listp obj)
+      (mapcar (lambda (obj) (evil-parser--dval obj result)) obj)
+    (let ((num (evil-parser--dexp obj)))
+      (if num
+          (if (not (listp result))
+              result
+            (if (eq num 0)
+                `(list ,@result)
+              (nth (1- num) result)))
+        obj))))
+
 (defun evil-parser (string symbol grammar &optional greedy syntax)
   "Parse STRING as a SYMBOL in GRAMMAR.
 If GREEDY is non-nil, the whole of STRING must match.
@@ -1102,54 +1129,34 @@ The following symbols have reserved meanings within a grammar:
       ;; semantic action
       (when (and pair func (not syntax))
         (setq result (car pair))
-        (let* ((dexp
-                #'(lambda (obj)
-                    (when (symbolp obj)
-                      (let ((str (symbol-name obj)))
-                        (save-match-data
-                          (when (string-match "\\$\\([0-9]+\\)" str)
-                            (string-to-number (match-string 1 str))))))))
-               ;; traverse a tree for dollar expressions
-               (dval nil)
-               (dval
-                #'(lambda (obj)
-                    (if (listp obj)
-                        (mapcar dval obj)
-                      (let ((num (funcall dexp obj)))
-                        (if num
-                            (if (not (listp result))
-                                result
-                              (if (eq num 0)
-                                  `(list ,@result)
-                                (nth (1- num) result)))
-                          obj))))))
-          (cond
-           ((null func)
-            (setq result nil))
-           ;; lambda function
-           ((eq (car-safe func) 'lambda)
-            (if (memq symbol '(+ seq))
-                (setq result `(funcall ,func ,@result))
-              (setq result `(funcall ,func ,result))))
-           ;; string replacement
-           ((or (stringp func) (stringp (car-safe func)))
-            (let* ((symbol (or (car-safe (cdr-safe func))
-                               (and (boundp 'context) context)
-                               (car-safe (car-safe grammar))))
-                   (string (if (stringp func) func (car-safe func))))
-              (setq result (car-safe (evil-parser string symbol grammar
-                                                  greedy syntax)))))
-           ;; dollar expression
-           ((funcall dexp func)
-            (setq result (funcall dval func)))
-           ;; function call
-           ((listp func)
-            (setq result (funcall dval func)))
-           ;; symbol
-           (t
-            (if (memq symbol '(+ seq))
-                (setq result `(,func ,@result))
-              (setq result `(,func ,result))))))
+        (cond
+         ((null func)
+          (setq result nil))
+         ;; lambda function
+         ((eq (car-safe func) 'lambda)
+          (if (memq symbol '(+ seq))
+              (setq result `(funcall ,func ,@result))
+            (setq result `(funcall ,func ,result))))
+         ;; string replacement
+         ((or (stringp func) (stringp (car-safe func)))
+          (let* ((symbol (or (car-safe (cdr-safe func))
+                             (and (boundp 'context) context)
+                             (car-safe (car-safe grammar))))
+                 (string (if (stringp func) func (car-safe func))))
+            (setq result (car-safe (evil-parser string symbol grammar
+                                                greedy syntax)))))
+         ;; dollar expression
+         ((evil-parser--dexp func)
+          (setq result (evil-parser--dval func result)))
+         ;; function call
+         ((listp func)
+          (setq result (evil-parser--dval func result)))
+         ;; symbol
+         (t
+          (message "action: symbol %S" func)
+          (if (memq symbol '(+ seq))
+              (setq result `(,func ,@result))
+            (setq result `(,func ,result)))))
         (setcar pair result))))
     ;; weed out incomplete matches
     (when pair

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -1,4 +1,4 @@
-;;; evil-integration.el --- Integrate Evil with other modules
+;;; evil-integration.el --- Integrate Evil with other modules -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -1,4 +1,4 @@
-;;; evil-jumps.el --- Jump list implementation
+;;; evil-jumps.el --- Jump list implementation -*- lexical-binding: t -*-
 
 ;; Author: Bailey Ling <bling at live.ca>
 

--- a/evil-keybindings.el
+++ b/evil-keybindings.el
@@ -1,4 +1,4 @@
-;;; evil-keybindings.el --- Add some Evil keybindings to other modules
+;;; evil-keybindings.el --- Add some Evil keybindings to other modules -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-macros.el
+++ b/evil-macros.el
@@ -1,4 +1,4 @@
-;;; evil-macros.el --- Macros
+;;; evil-macros.el --- Macros -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -1,4 +1,4 @@
-;;; evil-maps.el --- Default keymaps
+;;; evil-maps.el --- Default keymaps -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-repeat.el
+++ b/evil-repeat.el
@@ -1,4 +1,4 @@
-;;; evil-repeat.el --- Repeat system
+;;; evil-repeat.el --- Repeat system -*- lexical-binding: t -*-
 
 ;; Author: Frank Fischer <frank.fischer at mathematik.tu-chemnitz.de>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-search.el
+++ b/evil-search.el
@@ -1,4 +1,4 @@
-;;; evil-search.el --- Search and substitute
+;;; evil-search.el --- Search and substitute -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-states.el
+++ b/evil-states.el
@@ -1,4 +1,4 @@
-;;; evil-states.el --- States
+;;; evil-states.el --- States -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -1,4 +1,4 @@
-;;; evil-test-helpers.el --- unit test helpers for Evil -*- coding: utf-8 -*-
+;;; evil-test-helpers.el --- unit test helpers for Evil -*- coding: utf-8; lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-types.el
+++ b/evil-types.el
@@ -1,4 +1,4 @@
-;;; evil-types.el --- Type system
+;;; evil-types.el --- Type system -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1,4 +1,4 @@
-;;; evil-vars.el --- Settings and variables
+;;; evil-vars.el --- Settings and variables -*- lexical-binding: t -*-
 
 ;; Author: Vegard Øye <vegard_oye at hotmail.com>
 ;; Maintainer: Vegard Øye <vegard_oye at hotmail.com>


### PR DESCRIPTION
In the evil library itself there was only one change I had to do. The ex parser used some let-defined functions to deal with the 'dollar sign' forms in `evil-ex-grammar`. Once I converted them to properly named functions, all tests pass with lexical binding.

Unfortunately, some functions and macros in evil don't play well with lexical binding, so I left the test file itself alone for now. As far as I can tell, these are:

- `evil-define-key`: this is actually a macro which if given an unquoted symbol for the keymap first checks if it's bound, then binds the key if it is, or delays the binding if it isn't. This is a neat feature designed to avoid having users worry about `eval-after-load`, but unfortunately it just doesn't work with lexical binding and I don't see any way that it can do so sensibly. There are some issues open about this already. I would prefer to deprecate `evil-define-key` and create a new interface that behaves more predictably and let the user just deal with delaying.

- `evil-put-property`: for appending properties to a plist. Has the same issue as `add-to-list` does. This isn't really problematic, and we can work around it in test code.

- `evil-with-temp-file` in combination with `evil-test-buffer` used in read/write tests, the former macro let-binds the filename of the temporary file to a variable, but it's read by the latter macro using `eval`, so that won't work.