### PR TITLE
Change the way to get universal argument

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1927,7 +1927,8 @@ The default for width is the value of `fill-column'."
   "Pastes the latest yanked text before the cursor position.
 The return value is the yanked text."
   :suppress-operator t
-  (interactive "p<x>")
+  (interactive "*P<x>")
+  (setq count (prefix-numeric-value count))
   (if (evil-visual-state-p)
       (evil-visual-paste count register)
     (evil-with-undo
@@ -1974,7 +1975,8 @@ The return value is the yanked text."
   "Pastes the latest yanked text behind point.
 The return value is the yanked text."
   :suppress-operator t
-  (interactive "p<x>")
+  (interactive "*P<x>")
+  (setq count (prefix-numeric-value count))
   (if (evil-visual-state-p)
       (evil-visual-paste count register)
     (evil-with-undo
@@ -2022,7 +2024,8 @@ The return value is the yanked text."
 (evil-define-command evil-visual-paste (count &optional register)
   "Paste over Visual selection."
   :suppress-operator t
-  (interactive "p<x>")
+  (interactive "*P<x>")
+  (setq count (prefix-numeric-value count))
   ;; evil-visual-paste is typically called from evil-paste-before or
   ;; evil-paste-after, but we have to mark that the paste was from
   ;; visual state


### PR DESCRIPTION
It's better to unify the way between `evil-paste-*` and `yank*` to handle with universal argument, so spacemacs can do extra hook to them.
Refer: syl20bnr/spacemacs#13161