### PR TITLE
Makefile: add 'info' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ docstrings:
 doc: docstrings
 	@$(MAKE) -C doc texinfo
 
+info: doc
+	@$(MAKE) -C doc info
+
 # Delete byte-compiled files etc.
 clean:
 	rm -f *~


### PR DESCRIPTION
Useful to have a specific info target when some Emacs package installers
expect this target (such as el-get).