### PR TITLE
Correct typo (COMPOUNT->COMPOUND) in symbol name

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2045,7 +2045,7 @@ The following special registers are supported.
               (let ((what (if (eq register ?*) 'PRIMARY 'CLIPBOARD))
                     (request-type (or (and (boundp 'x-select-request-type)
                                            x-select-request-type)
-                                      '(UTF8_STRING COMPOUNT_TEXT STRING)))
+                                      '(UTF8_STRING COMPOUND_TEXT STRING)))
                     text)
                 (unless (consp request-type)
                   (setq request-type (list request-type)))


### PR DESCRIPTION
Correct typo (COMPOUNT->COMPOUND) in symbol name in window server selection data-type list.
Should correspond with the symbol used [in the emacs source code](https://github.com/emacs-mirror/emacs/blob/master/lisp/select.el#L306) and [in the emacs ipc encoding documentation](https://www.gnu.org/software/emacs/manual/html_node/emacs/Communication-Coding.html).
