### PR TITLE
Don't pass &rest to ignore in evil-define-command

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -367,7 +367,7 @@ sorting in between."
           `(defun ,command ,args
              ,@(when doc `(,doc))
              ,interactive
-             (ignore ,@(remq '&optional args))
+             (ignore ,@(cl-set-difference args '(&optional &rest)))
              ,@body))
        ,(when (and command doc-form)
           `(put ',command 'function-documentation ,doc-form))


### PR DESCRIPTION
At the moment, having `&rest` in a command's argument list results in the following error when running the command:
```
Symbol's value as variable is void: &rest
```