### PR TITLE
fix `wrong number of argument error` in evil-ex-command-window

### DIFF
--- a/evil-command-window.el
+++ b/evil-command-window.el
@@ -87,7 +87,7 @@ it will be used as the function to execute instead of
         (config (current-window-configuration)))
     (evil-ex-teardown)
     (select-window (minibuffer-selected-window) t)
-    (evil-ex-command-window current (apply-partially 'evil-ex-command-window-execute config))))
+    (evil-command-window-ex current (apply-partially 'evil-ex-command-window-execute config))))
 
 (defun evil-ex-search-command-window ()
   "Start command window with search history and current minibuffer content."


### PR DESCRIPTION
- evil-ex-command-window only accepts 0 arguments
- and it doesn't make sense to call itself recursively
- this issue was introduced in [1: 48ceb43]

1: 48ceb43f8a1e95e6d7eafe428ff640d83952462f
   Clean up compilation warnings from lexical binding