### PR TITLE
Make evil-goto-definition-xref return non-nil on success

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2766,7 +2766,9 @@ The search is unbounded, i.e., the pattern is not wrapped in
                         (goto-char position)
                         (xref-backend-identifier-at-point (xref-find-backend)))))
       (condition-case ()
-          (xref-find-definitions identifier)
+          (progn
+            (xref-find-definitions identifier)
+            t)
         (user-error nil)))))
 
 (defun evil-goto-definition-search (string _position)


### PR DESCRIPTION
# Description

It seems that `xref-find-definitions` returns `nil` on success, at least on Emacs 26.3.  This means that the `run-hook-with-args-until-success` call in `evil-goto-definition` will call the next search function even if `xref` is successful.

This PR makes `evil-goto-definition-xref` return `t` as long as there's no `user-error` raised (i.e. `xref` didn't fail to find a match).  ~I also added `(require 'xref)` to `evil-commands.el`, since I get an error with the below steps without it.~

# Steps to Reproduce the Issue

1. Run Emacs with `make emacs` using Evil's Makefile.
2. Evaluate the following, since `evil-goto-definition-imenu` will succeed:

``` emacs-lisp
(require 'xref)  ; "Symbol’s function definition is void: xref-backend-identifier-at-point"
(setq evil-goto-definition-functions '(evil-goto-definition-xref evil-goto-definition-search))
```

3. Open `evil-states.el` and navigate to line 45, placing the cursor on `evil-normal-post-command`.
4. Execute `evil-goto-definition` with `gd`.

The cursor will end up on line 43 (the first occurrence of the symbol) instead of the actual definition on line 47.  With `M-x xref-find-definitions`, the correct definition is found.
