### PR TITLE
Fix issue 1295: failed visual-paste from registers >1

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2041,8 +2041,7 @@ The return value is the yanked text."
          new-kill
          paste-eob)
     (evil-with-undo
-      (let* ((kill-ring (list (current-kill 0)))
-             (kill-ring-yank-pointer kill-ring))
+      (let ((kill-ring-yank-pointer (list (current-kill 0))))
         (when (evil-visual-state-p)
           (evil-visual-rotate 'upper-left)
           ;; if we replace the last buffer line that does not end in a
@@ -2058,13 +2057,12 @@ The return value is the yanked text."
                      (not (= evil-visual-end (point-max))))
             (insert "\n"))
           (evil-normal-state)
-          (setq new-kill (current-kill 0))
           (current-kill 1))
         (if paste-eob
             (evil-paste-after count register)
           (evil-paste-before count register)))
       (when evil-kill-on-visual-paste
-        (kill-new new-kill))
+        (current-kill -1))
       ;; mark the last paste as visual-paste
       (setq evil-last-paste
             (list (nth 0 evil-last-paste)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2592,7 +2592,20 @@ This bufferThis bufferThis buffe[r];; and for Lisp evaluation."))
 ;; [I]f you want to create a file, visit that file with C-x C-f."
     ("Vp")
     ";; This buffer is for notes you don't want to save.
-\[;]; This buffer is for notes you don't want to save."))
+\[;]; This buffer is for notes you don't want to save.")
+  (ert-info ("Visual-paste from register 3")
+    ;; This behaviour deviates from vim, which populates registers 1-9 with
+    ;; deleted text only, not yanked text. This is an aspect of `evil-yank's
+    ;; use of the emacs kill-ring, so is consistent with non-visual paste.
+    (evil-test-buffer
+     "[w]ord1a word1b word1c word1d
+word2a word2b word2c word2d"
+     ("yiwwyiwwyiw")
+     "word1a word1b [w]ord1c word1d
+word2a word2b word2c word2d"
+     ("+viw\"3p")
+     "word1a word1b word1c word1d
+word1[a] word2b word2c word2d")))
 
 (ert-deftest evil-test-visual-paste-pop ()
   "Test `evil-paste-pop' after visual paste."


### PR DESCRIPTION
The `kill-ring` let binding in `evil-visual-paste` meant that
`evil-get-register`'s view of `kill-ring` (used in `evil-paste-before`
and `evil-paste-after`) was limited to only entry `0` (and whatever
`evil-delete` may have added to rebound `kill-ring`). Therefore,
registers >1 were not actually visible to functions that needed
them. Condensing the `let*` binding so `kill-ring-yank-pointer` is
bound directly to `(list (current-kill 0))` was chosen as a simple and
effective method to fix the bug.

Fix for issue #1295 