### PR TITLE
Fixed make clean and doc build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,11 +10,15 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@if [ command -v $(SPHINXBUILD) 2> /dev/null ]; then \
+	  $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O); \
+	fi
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@if [ command -v $(SPHINXBUILD) 2> /dev/null ]; then \
+	  $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O); \
+	fi


### PR DESCRIPTION
When sphinx is not found, make clean (and others) will fail. This
change prevents running sphinx if sphinx-build binary is not found.

Here is used 'command' instead of 'which', for checking presence of
binary in PATH, to make it more portable across shells and unixes.