### PR TITLE
Default `exwm-mode` to Emacs state

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -735,6 +735,7 @@ expression matching the buffer's name and STATE is one of `normal',
     emms-playlist-mode
     ess-help-mode
     etags-select-mode
+    exwm-mode
     fj-mode
     gc-issues-mode
     gdb-breakpoints-mode


### PR DESCRIPTION
EXWM buffers display X windows, as such it is not useful to be in an Evil state as there is no text to manipulate. Being in normal state causes some problems, for example the simulation key feature does not work well in normal mode (as documented at https://github.com/ch11ng/exwm/wiki/Notes-to-Spacemacs-users#simulation-keys).