### PR TITLE
Exit search prompt on mouse leave minibuffer

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -890,6 +890,7 @@ message to be shown. This function does nothing if
   (remove-hook 'minibuffer-setup-hook #'evil-ex-search-start-session)
   (add-hook 'after-change-functions #'evil-ex-search-update-pattern nil t)
   (add-hook 'minibuffer-exit-hook #'evil-ex-search-stop-session)
+  (add-hook 'mouse-leave-buffer-hook #'evil-ex-search-exit)
   (evil-ex-search-activate-highlight nil))
 (put 'evil-ex-search-start-session 'permanent-local-hook t)
 
@@ -906,6 +907,7 @@ message to be shown. This function does nothing if
     (setq isearch-opened-overlays (delete-dups isearch-opened-overlays))
     (isearch-clean-overlays))
   (remove-hook 'minibuffer-exit-hook #'evil-ex-search-stop-session)
+  (remove-hook 'mouse-leave-buffer-hook #'evil-ex-search-exit)
   (remove-hook 'after-change-functions #'evil-ex-search-update-pattern t)
   (when evil-ex-search-overlay
     (delete-overlay evil-ex-search-overlay)


### PR DESCRIPTION
When using the search module: `evil-search`
And a search prompt is opened: `/` or `?`

If a window is mouse selected, then the search prompt remains active in the minibuffer.

Now when single pressing a operator key: `c`, `d`, `y`
then it behaves as if it was double pressed: `cc`, `dd`, `yy`
meaning that it acts on the current line.

---

#### Reproduction steps
- Switch to the `*scratch*` buffer
- Type:
```
a
b
c
d
```
- Enable the search module: `evil-search`
by evaluating: `S-M-;`
```elisp
(evil-select-search-module 'evil-search-module 'evil-search)
```
- Open a search prompt with: `/` or `?`
- Without closing the prompt, mouse select another window.

#### With the search module: `evil-search`
The search prompt remains active,
but now some evil bindings don't work as expected:
- `c` works as `cc` which deletes the line and enters insert state.
- `d` works as `dd` which deletes the line.
- `y` works as `yy` which copies the line.

#### With the default search module: `isearch`
When mouse selecting another window, then the search prompt closes, 
and the evil bindings work as expected.

All three key bindings `c`, `d` and `y` changes the cursor height to the bottom half, 
which means that it waits for a motion key to be pressed.

### Remaining issue
This PR only solves the issue when mouse selecting another window.
The issue remains if another window is selected with without the mouse: `C-x o`
In Spacemacs another window can also be selected with:
- `M-1` (or another window number)
- `M-m 1` (or another window number)
- `M-m w w`

This only happens with the search module: `evil-search`
The search prompt closes with the module: `isearch`
```elisp
(evil-select-search-module 'evil-search-module 'evil-search)
```

---

The evil-search issue has been reported here:
Evil search bug breaks Spacemacs https://github.com/syl20bnr/spacemacs/issues/10410

This is related but it doesn't seem to mention `evil`:
https://www.reddit.com/r/emacs/comments/4d8gvt/how_do_i_automatically_close_the_minibuffer_after/

There the suggestion is to use:
```elisp
(add-hook 'window-configuration-change-hook #'kill-minibuffer)
```
I tried changing it to:
```elisp
(add-hook 'window-configuration-change-hook #'evil-ex-search-exit)
```
But that hook doesn't seem to be called when selecting another window.
I tried adding a message when the `window-configuration-hook` is called, 
but the message never appears in the messages buffer.
It's docstring says:
>Documentation:
Functions to call when window configuration changes.
The buffer-local value is run once per window, with the relevant window
selected; while the global value is run only once for the modified frame,
with the relevant frame selected.

So it might only be called when the window configurations are changed.

A sub comment on that reddit thread:
https://www.reddit.com/r/emacs/comments/4d8gvt/how_do_i_automatically_close_the_minibuffer_after/d1p78tl/
suggests using: `focus-out-hook`
docstring:
>Normal hook run when all frames lost input focus.

but as the docstring describes it only gets called when Emacs looses focus.

If it was used, then it would add an extra step of switching to another application 
and back to Emacs with for example: `M-TAB` (assuming that another application is open).

I haven't been able to find a hook that could be used to detect when the minibuffer looses focus.

#### System info
Evil version 1.14.0
GNU Emacs 26.3 (build 1, x86_64-w64-mingw32) of 2019-08-29
Windows 1903