### PR TITLE
Fix the behavior of `C-w C-c`

### DIFF
--- a/evil-maps.el
+++ b/evil-maps.el
@@ -146,7 +146,7 @@
 (define-key evil-window-map "=" 'balance-windows)
 (define-key evil-window-map "|" 'evil-window-set-width)
 (define-key evil-window-map "\C-b" 'evil-window-bottom-right)
-(define-key evil-window-map "\C-c" 'evil-window-delete)
+(define-key evil-window-map "\C-c" 'ignore)
 (define-key evil-window-map (kbd "C-S-h") 'evil-window-move-far-left)
 (define-key evil-window-map (kbd "C-S-j") 'evil-window-move-very-bottom)
 (define-key evil-window-map (kbd "C-S-k") 'evil-window-move-very-top)


### PR DESCRIPTION
Here's another small PR, this time to fix an inconsistency I've noticed with respect to Vim behavior.

In Evil `C-w C-c` has been closing the current window.  This behavior appears to have been silently introduced in commit ec53465dafc99357161dffc53d49592914d628e5.

Vim, however, doesn't close the window in this case.  From the Vim documentation:

> You might have expected that CTRL-W CTRL-C closes the current
> window, but that does not work, because the CTRL-C cancels the
> command.

Now use `ignore` instead of `evil-window-delete` so nothing happens in this case (specifically, we do keep it defined so we don't get the message "C-w C-c is undefined").

Thanks!