### PR TITLE
Add integration with go-mode

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -523,6 +523,10 @@ Based on `evil-enclose-ace-jump-for-motion'."
 (eval-after-load 'abbrev
   '(add-hook 'evil-insert-state-exit-hook 'evil-maybe-expand-abbrev))
 
+;;; go-mode
+(eval-after-load 'go-mode
+  '(evil-set-command-property 'godef-jump :jump t))
+
 ;;; ElDoc
 (eval-after-load 'eldoc
   '(when (fboundp 'eldoc-add-command-completions)


### PR DESCRIPTION
This change fixes #1337.

* `evil-integration.el`: When go-mode is loaded, mark `godef-jump` as a jump command so that `evil-jump-backward` works properly with it.