### PR TITLE
Fix for issue #730 appending to macro fails

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2150,6 +2150,9 @@ The following special registers are supported.
     (cond
      ((not content)
       (set-register register text))
+     ((not (stringp content))
+      ;; if the register does not contain a string treat it as a vector
+      (set-register register (vconcat content text)))
      ((or (text-property-not-all 0 (length content)
                                  'yank-handler nil
                                  content)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8386,6 +8386,16 @@ when an error stops the execution of the macro"
       ;; should not raise an "Selecting deleted buffer" error
       (evil-visual-update-x-selection buf))))
 
+(ert-deftest evil-test-append-to-kbd-macro ()
+  "Test if evil can append to a keyboard macro."
+  :tags '(evil append to kbd-macro)
+  (ert-info ("When kbd-macro ends in <escape>")
+    (evil-test-buffer
+     (evil-set-register ?a (vconcat "ainserted text" [escape]))
+     (evil-set-register ?A (vconcat "a appended text" [escape]))
+     ("@a")
+     "inserted text appended tex[t]")))
+
 ;;; Core
 
 (ert-deftest evil-test-initial-state ()


### PR DESCRIPTION
Cope with non-string register contents. Fixes #730 