### PR TITLE
Fix evil-ex-search-word-forward with evil-ex-search-vim-style-regexp

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -1151,7 +1151,8 @@ point."
         (setq evil-ex-search-count count
               evil-ex-search-direction direction
               evil-ex-search-pattern
-              (evil-ex-make-search-pattern regex)
+              (let (evil-ex-search-vim-style-regexp)
+                (evil-ex-make-search-pattern regex))
               evil-ex-search-offset nil
               evil-ex-last-was-search t)
         ;; update search history unless this pattern equals the

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7337,7 +7337,15 @@ maybe we need one line more with some text\n"
         ("*")
         "(defun my-symbol-func ())\n(defvar my-symbol-var)\n([m]y-symbol-func)\n(setq my-symbol-func2 (my-symbol-func))\n"
         ("n")
-        "(defun my-symbol-func ())\n(defvar my-symbol-var)\n(my-symbol-func)\n(setq my-symbol-func2 ([m]y-symbol-func))\n"))))
+        "(defun my-symbol-func ())\n(defvar my-symbol-var)\n(my-symbol-func)\n(setq my-symbol-func2 ([m]y-symbol-func))\n"))
+    (ert-info ("Test with non-nil `evil-ex-search-vim-style-regexp'")
+      (evil-select-search-module 'evil-search-module 'evil-search)
+      (let ((evil-ex-search-vim-style-regexp t)
+            (evil-magic 'very-magic))
+        (evil-test-buffer
+          "[a]lpha bravo alpha charlie"
+          ("*")
+          "alpha bravo [a]lpha charlie")))))
 
 (ert-deftest evil-test-isearch-word ()
   "Test isearch for word under point."


### PR DESCRIPTION
Disable `evil-ex-search-vim-style-regexp` when building the pattern for `evil-ex-search-word-forward`. We don't want the pattern transformed because it is not being entered by the user. Closes #347