### PR TITLE
Silence byte compiler warnings

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2038,7 +2038,6 @@ The return value is the yanked text."
                  (current-kill 0)))
          (yank-handler (car-safe (get-text-property
                                   0 'yank-handler text)))
-         new-kill
          paste-eob)
     (evil-with-undo
       (let ((kill-ring-yank-pointer (list (current-kill 0))))

--- a/evil-common.el
+++ b/evil-common.el
@@ -125,7 +125,8 @@ otherwise add at the end of the list."
       (set list-var (append (symbol-value list-var)
                             (list (cons key val)))))
     (if elements
-        (apply #'evil-add-to-alist list-var elements)
+        (with-no-warnings
+          (apply #'evil-add-to-alist list-var elements))
       (symbol-value list-var))))
 
 (make-obsolete 'evil-add-to-alist


### PR DESCRIPTION
* `evil-commands.el` (`evil-visual-paste`): Delete declaration of the `new-kill` variable to silence the byte compiler.  The variable is unused since https://github.com/emacs-evil/evil/pull/1296.
* `evil-common.el` (`evil-add-to-alist`): Use `with-no-warnings` around the recursive obsolete function call to silence the byte compiler.