### PR TITLE
Fix multiline tag text object.

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1529,7 +1529,7 @@ last successful match (that caused COUNT to reach zero)."
         (while
             (and (setq match
                        (re-search-forward
-                        "<\\([^/ >]+\\)\\(?:[^\"/>]\\|\"[^\"]*\"\\)*?>\\|</\\([^>]+?\\)>"
+                        "<\\([^/ >\n]+\\)\\(?:[^\"/>]\\|\"[^\"]*\"\\)*?>\\|</\\([^>]+?\\)>"
                         nil t dir))
                  (cond
                   ((match-beginning op)
@@ -1563,7 +1563,7 @@ last successful match (that caused COUNT to reach zero)."
         (let* ((tag (match-string cl))
                (refwd (concat "<\\(/\\)?"
                               (regexp-quote tag)
-                              "\\(?:>\\| \\(?:[^\"/>]\\|\"[^\"]*\"\\)*?>\\)"))
+                              "\\(?:>\\|[ \n]\\(?:[^\"/>]\\|\"[^\"]*\"\\)*?>\\)"))
                (cnt 1))
           (while (and (> cnt 0) (re-search-backward refwd nil t dir))
             (setq cnt (+ cnt (if (match-beginning 1) dir (- dir)))))


### PR DESCRIPTION
Text objects for tags didn't work as expected when tag has attribute (or just closing angle brackets) in next line.

For example, try to select (type `vat` in normal mode) this tag:
```xml
<foo
>
</foo>
```

Or this:
```xml
<foo
someAttribute="value"
>
</foo>
```