### PR TITLE
Fix documentation building.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@if [ command -v $(SPHINXBUILD) 2> /dev/null ]; then \
+	@if command -v $(SPHINXBUILD) >/dev/null; then \
 	  $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O); \
 	fi
 
@@ -19,6 +19,6 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@if [ command -v $(SPHINXBUILD) 2> /dev/null ]; then \
+	@if command -v $(SPHINXBUILD) >/dev/null; then \
 	  $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O); \
 	fi


### PR DESCRIPTION
Currently, cloning master and running:

cd doc && make info

Does nothing for me.

The problem seems to be the use of /usr/bin/[ and a command without a
comparison introduced in #1314.

If you remove the redirection of stderr to /dev/null, you'll see:

$ if [ command -v sphinx-build ]; then echo foo; fi
bash: [: -v: binary operator expected

Simply running the command without /usr/bin/[ has the intended behavior.