### PR TITLE
evil-vars: Update evil-insert-state-modes

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -858,11 +858,13 @@ expression matching the buffer's name and STATE is one of `normal',
     inferior-scheme-mode
     inferior-sml-mode
     internal-ange-ftp-mode
+    haskell-interactive-mode
     prolog-inferior-mode
     reb-mode
     shell-mode
     slime-repl-mode
     term-mode
+    utop-mode
     wdired-mode)
   "Modes that should come up in Insert state."
   :type  '(repeat symbol)


### PR DESCRIPTION
`haskell-interactive-mode` and `utop-mode` are REPL-like modes that both
inherit from `fundamental-mode`, so they need to be explicitly listed here.