### PR TITLE
Update readme, redo choices as a sublist

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ file.
 * Evil requires Emacs 24.1 or later.
 
 * Evil requires any of the following for `C-r`:
-** `undo-redo` from Emacs 28
-** The [undo-tree](http://www.emacswiki.org/emacs/UndoTree) package
-** The [undo-fu](https://gitlab.com/ideasman42/emacs-undo-fu) package
+  * `undo-redo` from Emacs 28
+  * The [undo-tree](http://www.emacswiki.org/emacs/UndoTree) package
+  * The [undo-fu](https://gitlab.com/ideasman42/emacs-undo-fu) package
 
 * For the motions `g;` `g,` and for the last-change-register `.`, Evil requires the
 [goto-chg.el](https://github.com/emacs-evil/goto-chg) package,


### PR DESCRIPTION
Currently the choices are listed on a single line.
The intention with the double asterisks, was probably to indent them as a sublist.

Adding two spaces before one asterisk accomplishes this.

source:
https://guides.github.com/features/mastering-markdown/
Lists
Unordered