### PR TITLE
Mention evil-move-beyond-eol in docstring of evil-move-cursor-back

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -234,7 +234,9 @@ current line.  This applies to \\[evil-backward-char], \
   "Whether the cursor is moved backwards when exiting insert state.
 If non-nil, the cursor moves \"backwards\" when exiting insert state,
 so that it ends up on the character to the left.  Otherwise it remains
-in place, on the character to the right."
+in place, on the character to the right.
+
+See also `evil-move-beyond-eol'."
   :type 'boolean
   :group 'evil)
 


### PR DESCRIPTION
aa3ea1dcfc54fe25581841a8685679d482e99b3f unwed these, but they should
still keep in touch (so people can easily find out why behaviour
changed).