### PR TITLE
Add missing indent declaration to evil-define-key*

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -1104,6 +1104,7 @@ consequences). `evil-define-key*' also does not defer any
 bindings like `evil-define-key' does using `evil-delay'. This
 allows errors in the bindings to be caught immediately, and makes
 its behavior more predictable."
+  (declare (indent defun))
   (let ((maps
          (if state
              (mapcar


### PR DESCRIPTION
While chatting with @angrybacon we realized that `evil-define-key*` was missing the `(declare (indent defun))` which prevents it from being indented the same as `evil-define-key`.  This PR adds the expected declaration to get that indentation behavior.