### PR TITLE
`evil-jump-item': don't error at `point-max'

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1894,6 +1894,7 @@ won't be considered as comment starters inside a string or
 possibly another comment. Point is moved to the first character
 of the comment opener if MOVE is non-nil."
   (cond
+   ((= (point) (point-max)) nil)
    ;; one character opener
    ((= (char-syntax (char-after)) ?<)
     (equal (point) (evil-in-comment-p (1+ (point)))))


### PR DESCRIPTION
`evil-jump-item` internally calls `evil-looking-at-start-comment`, which
fails at `point-max` because it checks `char-after` using `char-syntax`. Return
nil in it if `point` = `point-max`, because a comment cannot start at the end of
the buffer (it would be 0 characters long).


----

#