### PR TITLE
Add version to `define-obsolete-function-alias' invocation

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -595,7 +595,7 @@ argument handler that requires shell completion."
 
 (define-obsolete-function-alias
   'evil-ex-shell-command-completion-at-point
-  'comint-completion-at-point)
+  'comint-completion-at-point "1.2.13")
 
 (evil-ex-define-argument-type shell
   "Shell argument type, supports completion."


### PR DESCRIPTION
The latest Emacs 28 requires this.