### PR TITLE
`evil-ex`: elisp: eldoc

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -257,12 +257,10 @@ interactive actions during ex state."
   (when evil-ex-previous-command
     (add-hook 'pre-command-hook #'evil-ex-remove-default))
   (remove-hook 'minibuffer-setup-hook #'evil-ex-setup)
-  (with-no-warnings
-    (make-variable-buffer-local 'completion-at-point-functions))
-  (setq completion-at-point-functions
-        '(evil-ex-elisp-completion-at-point
-          evil-ex-command-completion-at-point
-          evil-ex-argument-completion-at-point))
+  (set (make-local-variable 'completion-at-point-functions)
+       '(evil-ex-elisp-completion-at-point
+         evil-ex-command-completion-at-point
+         evil-ex-argument-completion-at-point))
   (add-function :before-until (local 'eldoc-documentation-function)
                 #'evil-ex-elisp-eldoc-function)
   (eldoc-mode 1))

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -229,6 +229,24 @@ Otherwise behaves like `delete-backward-char'."
   (insert result)
   (exit-minibuffer))
 
+(defun evil-ex--elisp-p ()
+  "Check if `evil-ex' is executing an elisp expression."
+  (string-prefix-p "(" (minibuffer-contents-no-properties)))
+
+(defun evil-ex-elisp-completion-at-point ()
+  "Complete an `evil-ex' Elisp expression."
+  (when (and (fboundp 'elisp-completion-at-point)
+             (evil-ex--elisp-p))
+    (elisp-completion-at-point)))
+
+(defun evil-ex-elisp-eldoc-function ()
+  "`eldoc' for `evil-ex' Elisp expressions.
+Only provides an `eldoc' hint if the current `evil-ex' command is
+an elisp expression."
+  (when (and (fboundp 'elisp-eldoc-documentation-function)
+             (evil-ex--elisp-p))
+    (elisp-eldoc-documentation-function)))
+
 (defun evil-ex-setup ()
   "Initialize Ex minibuffer.
 This function registers several hooks that are used for the
@@ -242,8 +260,12 @@ interactive actions during ex state."
   (with-no-warnings
     (make-variable-buffer-local 'completion-at-point-functions))
   (setq completion-at-point-functions
-        '(evil-ex-command-completion-at-point
-          evil-ex-argument-completion-at-point)))
+        '(evil-ex-elisp-completion-at-point
+          evil-ex-command-completion-at-point
+          evil-ex-argument-completion-at-point))
+  (add-function :before-until (local 'eldoc-documentation-function)
+                #'evil-ex-elisp-eldoc-function)
+  (eldoc-mode 1))
 (put 'evil-ex-setup 'permanent-local-hook t)
 
 (defun evil-ex-setup-and-update ()
@@ -261,7 +283,9 @@ Clean up everything set up by `evil-ex-setup'."
     (let ((runner (evil-ex-argument-handler-runner
                    evil-ex-argument-handler)))
       (when runner
-        (funcall runner 'stop)))))
+        (funcall runner 'stop))))
+  (remove-function (local 'eldoc-documentation-function) #'evil-ex-elisp-eldoc-function)
+  (eldoc-mode -1))
 (put 'evil-ex-teardown 'permanent-local-hook t)
 
 (defun evil-ex-remove-default ()


### PR DESCRIPTION
Extend `evil-ex` with `eldoc` similar to `eval-expression` for LISP expressions.

----

#