### PR TITLE
Add "gf" to visual mode

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3398,6 +3398,15 @@ If FORCE is non-nil and MARKS is blank, all local marks except 0-9 are removed."
             (forward-line (1- line))))
       (user-error "File does not exist."))))
 
+(evil-define-command evil-find-file-at-point-visual ()
+  "Find the filename selected by the visual region.
+    Returns an error message if the file does not exist."
+  (require 'ffap)
+  (let ((region (buffer-substring (region-beginning) (region-end))))
+    (if (file-exists-p region)
+        (find-file-at-point region)
+      (user-error (format "Can't find file \"%s\" in path" region)))))
+
 (evil-ex-define-argument-type state
   "Defines an argument type which can take state names."
   :collection

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -360,6 +360,7 @@
 (define-key evil-visual-state-map (kbd "<insertchar>") 'undefined)
 (define-key evil-visual-state-map [remap evil-repeat] 'undefined)
 (define-key evil-visual-state-map [escape] 'evil-exit-visual-state)
+(define-key evil-visual-state-map "gf" 'evil-find-file-at-point-visual)
 
 ;;; Operator-Pending state
 

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -8378,6 +8378,23 @@ maybe we need one line more with some text\n")
             (set-buffer-modified-p nil))
           (kill-buffer (get-file-buffer temp-file)))))))
 
+(ert-deftest evil-test-find-file ()
+  :tags '(evil jumps)
+  (ert-info ("Normal mode find-file-at-point")
+    (evil-with-temp-file file-name ""
+      (evil-test-buffer
+        (vconcat "i" file-name [escape])
+        (should (not (equal file-name (buffer-file-name (current-buffer)))))
+        ("gf")
+        (should (equal file-name (buffer-file-name (current-buffer)))))))
+  (ert-info ("Visual mode evil-find-file-at-point-visual")
+    (evil-with-temp-file file-name ""
+      (evil-test-buffer
+        (vconcat "iuser@localhost:" file-name "$" [escape])
+        (should (not (equal file-name (buffer-file-name (current-buffer)))))
+        ("0f:lvt$gf")
+        (should (equal file-name (buffer-file-name (current-buffer))))))))
+
 (ert-deftest evil-test-jump-buffers ()
   :tags '(evil jums)
   (skip-unless nil)


### PR DESCRIPTION
Adds `evil-find-file-at-point-visual` for finding a file using the
selected visual region. (See `:h v_gf` in Vim)

Adds tests for "gf" in both normal and visual modes.