### PR TITLE
Added `evil-beginning-of-line-or-visual-line`

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -203,6 +203,18 @@ If COUNT is given, move COUNT - 1 lines downward first."
       (beginning-of-visual-line)
     (beginning-of-line)))
 
+(evil-define-motion evil-beginning-of-line-or-visual-line (count)
+  "Move the cursor to the first character of the current screen
+line if `visual-line-mode' is active and
+`evil-respect-visual-line-mode' is non-nil.  If COUNT is given,
+move COUNT - 1 screen lines forward first."
+  :type inclusive
+  (if (and (fboundp 'beginning-of-visual-line)
+           evil-respect-visual-line-mode
+           visual-line-mode)
+      (beginning-of-visual-line count)
+    (evil-beginning-of-line)))
+
 (evil-define-motion evil-end-of-visual-line (count)
   "Move the cursor to the last character of the current screen line.
 If COUNT is given, move COUNT - 1 screen lines downward first."


### PR DESCRIPTION
One thing I don't understand is why `evil-beginning-of-line` does not accept the `count` argument.

~~Also, when I move my cursor with `(evil-beginning-of-line)` (using `g 0` and `g $`, essentially) when `evil-respect-visual-line-mode` is on, my whole `evil` setup sometimes (70% of the time?) gets into a buggy state where doing, e.g., `dd` errors `evil-motion-range: Args out of range: nil, 2305843009213693951`.~~

Update: Using `g $` to go to the end of the line, goes to after the last character (which is a config thing I have turned on), and then using `dd` errors `evil-motion-range: Args out of range: nil, 2305843009213693951`. Even though `$` also goes to after the last character, this doesn't happen there. Should I open a separate issue?