### PR TITLE
Fix visual paste from `=` register by memoizing `evil-get-register`

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2135,7 +2135,7 @@ The return value is the yanked text."
                                   0 'yank-handler text)))
          paste-eob)
     (evil-with-undo
-      (let ((kill-ring-yank-pointer (list (current-kill 0))))
+      (let ((kill-ring-yank-pointer (when kill-ring (list (current-kill 0)))))
         (when (evil-visual-state-p)
           (evil-visual-rotate 'upper-left)
           ;; if we replace the last buffer line that does not end in a
@@ -2153,11 +2153,11 @@ The return value is the yanked text."
                      (not (= evil-visual-end (point-max))))
             (insert "\n"))
           (evil-normal-state)
-          (current-kill 1))
+          (when kill-ring (current-kill 1)))
         ;; Effectively memoize `evil-get-register' because it can be
         ;; side-effecting (e.g. for the `=' register)...
         (cl-letf (((symbol-function 'evil-get-register)
-                   (lambda (&rest _args) text)))
+                   (lambda (&rest _) text)))
           (if paste-eob
               (evil-paste-after count register)
             (evil-paste-before count register))))

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2154,9 +2154,13 @@ The return value is the yanked text."
             (insert "\n"))
           (evil-normal-state)
           (current-kill 1))
-        (if paste-eob
-            (evil-paste-after count register)
-          (evil-paste-before count register)))
+        ;; Effectively memoize `evil-get-register' because it can be
+        ;; side-effecting (e.g. for the `=' register)...
+        (cl-letf (((symbol-function 'evil-get-register)
+                   (lambda (&rest _args) text)))
+          (if paste-eob
+              (evil-paste-after count register)
+            (evil-paste-before count register))))
       (when evil-kill-on-visual-paste
         (current-kill -1))
       ;; mark the last paste as visual-paste

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2626,7 +2626,12 @@ word2[]")
      "word1 word2 word[1]"
      ("o\C-r\"")
      "word1 word2 word1
-word3[]")))
+word3[]"))
+  (ert-info ("Visual-paste from `=' register")
+    (evil-test-buffer
+     "foo"
+     ("viw" "\"=p(* 6 7)" [return])
+     "4[2]")))
 
 (ert-deftest evil-test-visual-paste-pop ()
   "Test `evil-paste-pop' after visual paste."


### PR DESCRIPTION
Fixes #1305 