### PR TITLE
Add bs-mode to evil-emacs-state-modes.

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -704,6 +704,7 @@ expression matching the buffer's name and STATE is one of `normal',
     bookmark-bmenu-mode
     bookmark-edit-annotation-mode
     browse-kill-ring-mode
+    bs-mode
     bubbles-mode
     bzr-annotate-mode
     calc-mode


### PR DESCRIPTION
Normal state's bindings don't work there by default. (And maybe) It's
not worthy for evil-collection to define them.