### PR TITLE
Repeat when execute in normal state

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4643,7 +4643,8 @@ This var stores the eol position, so it can be restored when necessary.")
   "Execute the next command in Normal state."
   (interactive)
   (evil-delay '(not (memq this-command
-                          '(evil-execute-in-normal-state
+                          '(nil
+                            evil-execute-in-normal-state
                             evil-replace-state
                             evil-use-register
                             digit-argument

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4639,6 +4639,17 @@ if the previous state was Emacs state."
   "Vim has special behaviour for executing in normal state at eol.
 This var stores the eol position, so it can be restored when necessary.")
 
+(defun evil--restore-repeat-hooks ()
+  "No insert-state repeat info is recorded after executing in normal state.
+Restore the disabled repeat hooks on insert-state exit."
+  (evil-repeat-stop)
+  (add-hook 'pre-command-hook 'evil-repeat-pre-hook)
+  (add-hook 'post-command-hook 'evil-repeat-post-hook)
+  (remove-hook 'evil-insert-state-exit-hook 'evil--restore-repeat-hooks))
+
+(defvar evil--execute-normal-return-state nil
+  "The state to return to after executing in normal state.")
+
 (defun evil-execute-in-normal-state ()
   "Execute the next command in Normal state."
   (interactive)
@@ -4662,12 +4673,17 @@ This var stores the eol position, so it can be restored when necessary.")
              (forward-char))
            (unless (eq 'replace evil-state)
              (evil-change-state ',evil-state))
+           (when (eq 'insert evil-state)
+             (remove-hook 'pre-command-hook 'evil-repeat-pre-hook)
+             (remove-hook 'post-command-hook 'evil-repeat-post-hook)
+             (add-hook 'evil-insert-state-exit-hook 'evil--restore-repeat-hooks))
            (setq evil-move-cursor-back ',evil-move-cursor-back
                  evil-move-beyond-eol ',evil-move-beyond-eol)))
     'post-command-hook)
-  (setq evil-insert-count nil)
-  (setq evil--execute-normal-eol-pos (when (eolp) (point)))
-  (setq evil-move-cursor-back nil)
+  (setq evil-insert-count nil
+        evil--execute-normal-return-state evil-state
+        evil--execute-normal-eol-pos (when (eolp) (point))
+        evil-move-cursor-back nil)
   (evil-normal-state)
   (setq evil-move-beyond-eol t)
   (evil-echo "Switched to Normal state for the next command ..."))

--- a/evil-repeat.el
+++ b/evil-repeat.el
@@ -50,9 +50,9 @@
 ;;                             \___/
 ;;
 ;; The recording of a repeat is started in one of two cases: Either a
-;; command is about being executed (in pre-command-hook) or normal
+;; command is about to be executed (in pre-command-hook) or normal
 ;; state is exited. The recording is stopped whenever a command has
-;; being completed and evil is in normal state afterwards. Therefore,
+;; been completed and evil is in normal state afterwards. Therefore,
 ;; a non-inserting command in normal-state is recorded as a single
 ;; repeat unit. In contrast, if the command leaves normal state and
 ;; starts insert-state, all commands that are executed until
@@ -63,7 +63,7 @@
 ;;
 ;; Not all commands are recorded. There are several commands that are
 ;; completely ignored and other commands that even abort the currently
-;; active recording, e.g., commands that change the current buffer.
+;; active recording, e.g., commands that switch buffer.
 ;;
 ;; During recording the repeat information is appended to the variable
 ;; `evil-repeat-info', which is cleared when the recording

--- a/evil-repeat.el
+++ b/evil-repeat.el
@@ -399,8 +399,8 @@ If CHANGE is specified, it is added to `evil-repeat-changes'."
 
 (defun evil-repeat-insert-at-point (flag)
   "Repeation recording function for commands that insert text in region.
-This records text insertion when a command inserts some text in a
-buffer between (point) and (mark)."
+For example `mouse-yank-primary'. This records text insertion when a command
+inserts some text in a buffer between (point) and (mark)."
   (cond
    ((eq flag 'pre)
     (add-hook 'after-change-functions #'evil-repeat-insert-at-point-hook nil t))
@@ -580,7 +580,9 @@ If SAVE-POINT is non-nil, do not move point."
             (evil-execute-repeat-info-with-count
              count (ring-ref evil-repeat-ring 0))
             (setq evil-last-find evil-last-find-temp)))
-      (evil-normal-state)))))
+      (if (eq 'evil-execute-in-normal-state last-command)
+          (evil-change-state evil--execute-normal-return-state)
+        (evil-normal-state))))))
 
 ;; TODO: the same issue concering disabled undos as for `evil-paste-pop'
 (evil-define-command evil-repeat-pop (count &optional save-point)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -350,10 +350,13 @@ with `M-x evil-tests-run'"))
         "abcdeF[g]"))
     (ert-info ("Can execute evil-repeat in normal state")
       (evil-test-buffer
+        ;; Although this is the same in vim, text inserted after the temporary
+        ;; normal command is not recorded for repetition, which is a subtle
+        ;; (but arguably more useful) difference
         :state insert
-        "ab[]cdefg"
-        ("\C-o~\C-o.")
-        "abCD[]efg"))))
+        "ab[]cfg"
+        ("\C-o~de\C-o.")
+        "abCdeF[]g"))))
 
 (defun evil-test-suppress-keymap (state)
   "Verify that `self-insert-command' is suppressed in STATE"

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -347,7 +347,13 @@ with `M-x evil-tests-run'"))
       (evil-test-buffer
         "[]"
         ("2i" "abcdef" "\C-o~" "g" [escape])
-        "abcdeF[g]"))))
+        "abcdeF[g]"))
+    (ert-info ("Can execute evil-repeat in normal state")
+      (evil-test-buffer
+        :state insert
+        "ab[]cdefg"
+        ("\C-o~\C-o.")
+        "abCD[]efg"))))
 
 (defun evil-test-suppress-keymap (state)
   "Verify that `self-insert-command' is suppressed in STATE"


### PR DESCRIPTION
`evil-repeat` is currently broken when in the temporary normal state reached from `evil-execute-in-normal-state`. This PR fixes that.