### PR TITLE
Consider line-move-visual and last-command in evil-line-move

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1373,6 +1373,9 @@ Signals an error at buffer boundaries unless NOERROR is non-nil."
         (evil-line-move count)
       (error nil)))
    (t
+    (when (and line-move-visual
+               (memq last-command `(next-line previous-line)))
+      (setq last-command nil))
     (evil-signal-without-movement
       (setq this-command (if (>= count 0)
                              #'next-line


### PR DESCRIPTION
line-move is hard-coded such that it will not perform visual movements
when last-command is next-line or previous-line. If
line-move-visual is set, then we are trying to move the point visually,
but this will not happen if last-command is next-line or
previous-line. Thus, we set last-command to nil in these cases.

Fixes https://github.com/emacs-evil/evil/issues/1469