### PR TITLE
Add :window-width to `evil-test-buffer` args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
 
 script:
-  - tput cols
+  - stty cols 100 # Set to 100 so the default window-width of 80 can be set
   - emacs --version
   - script -eqc 'make test' > /dev/null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
 
 script:
+  - tput cols
   - emacs --version
   - script -eqc 'make test' > /dev/null
 

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -147,7 +147,8 @@ raised.  Remaining forms are evaluated as-is.
                (buffer-enable-undo)
                ;; set the window width for test buffer
                (when (> current-window-width (+ 2 ,window-width))
-                 (split-window (selected-window) (1+ ,window-width) 'right))
+                 (split-window (selected-window) (1+ ,window-width) 'right)
+                 (setq truncate-partial-width-windows nil))
                ;; parse remaining forms
                ,@(mapcar
                   #'(lambda (form)

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -78,6 +78,7 @@
 The following optional keywords specify the buffer's properties:
 
 :state STATE            The initial state, defaults to `normal'.
+:window-width NUMBER    The width of the test buffer's window, defaults to `80'.
 :visual SELECTION       The Visual selection, defaults to `char'.
 :point-start STRING     String for matching beginning of point,
                         defaults to \"[\".
@@ -103,6 +104,7 @@ raised.  Remaining forms are evaluated as-is.
 \(fn [[KEY VALUE]...] FORMS...)"
   (declare (indent defun))
   (let ((state 'normal)
+        (window-width 80)
         arg key point-start point-end string
         visual visual-start visual-end)
     ;; collect keywords
@@ -110,6 +112,8 @@ raised.  Remaining forms are evaluated as-is.
       (setq key (pop body)
             arg (pop body))
       (cond
+       ((eq key :window-width)
+        (setq window-width arg))
        ((eq key :point-start)
         (setq point-start (or arg "")))
        ((eq key :point-end)
@@ -140,6 +144,8 @@ raised.  Remaining forms are evaluated as-is.
                ;; necessary for keyboard macros to work
                (switch-to-buffer-other-window (current-buffer))
                (buffer-enable-undo)
+               ;; set the window width for test buffer
+               (split-window (selected-window) (1+ ,window-width) 'right)
                ;; parse remaining forms
                ,@(mapcar
                   #'(lambda (form)

--- a/evil-test-helpers.el
+++ b/evil-test-helpers.el
@@ -136,6 +136,7 @@ raised.  Remaining forms are evaluated as-is.
                     ',visual ,visual-start ,visual-end))
            (kill-ring kill-ring)
            (kill-ring-yank-pointer kill-ring-yank-pointer)
+           (current-window-width (window-width))
            evil-test-select-enable-clipboard
            message-log-max)
        (unwind-protect
@@ -145,7 +146,8 @@ raised.  Remaining forms are evaluated as-is.
                (switch-to-buffer-other-window (current-buffer))
                (buffer-enable-undo)
                ;; set the window width for test buffer
-               (split-window (selected-window) (1+ ,window-width) 'right)
+               (when (> current-window-width (+ 2 ,window-width))
+                 (split-window (selected-window) (1+ ,window-width) 'right))
                ;; parse remaining forms
                ,@(mapcar
                   #'(lambda (form)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -3065,6 +3065,24 @@ Below some empty line"
       (should-error (execute-kbd-macro "j"))
       (should-error (execute-kbd-macro "42j")))))
 
+(ert-deftest evil-test-next-visual-line ()
+  "Test `evil-next-visual-line' motion"
+  :tags '(evil motion)
+  (evil-test-buffer
+   :window-width 20
+   "T[h]is text wraps around the end of the line"
+   ("gj")
+   "This text wraps arou[n]d the end of the line"))
+
+(ert-deftest evil-test-previous-visual-line ()
+  "Test `evil-previous-visual-line' motion"
+  :tags '(evil motion)
+  (evil-test-buffer
+   :window-width 20
+   "This text wraps arou[n]d the end of the line"
+   ("gk")
+   "T[h]is text wraps around the end of the line"))
+
 (ert-deftest evil-test-preserve-column ()
   "Test `evil-previous-line' and `evil-next-line' preserve the column."
   :tags '(evil motion)


### PR DESCRIPTION
So we can reliably test visual-line related functionality.