### PR TITLE
Fix evil-find-char on empty line

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -766,7 +766,7 @@ Movement is restricted to the current line unless `evil-cross-lines' is non-nil.
         (visual (and evil-respect-visual-line-mode
                      visual-line-mode)))
     (setq evil-last-find (list #'evil-find-char char fwd))
-    (when fwd (forward-char))
+    (when fwd (evil-forward-char 1 evil-cross-lines))
     (let ((case-fold-search nil))
       (unless (prog1
                   (search-forward (char-to-string char)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -5159,7 +5159,12 @@ Below some empty line."))
 ;; and for Lisp evaluation."
         ("fL")
         ";; This buffer is for notes,
-;; and for [L]isp evaluation."))))
+;; and for [L]isp evaluation.")))
+  (ert-info ("Empty line")
+    (evil-test-buffer
+     "[]
+This buffer is for notes."
+     (should-error (execute-kbd-macro "fT")))))
 
 (ert-deftest evil-test-find-char-backward ()
   "Test `evil-find-char-backward'"


### PR DESCRIPTION
Previously, with the cursor on an empty line `evil-find-char` would continue searching on the next line. This was because `forward-char` would advance to the next line, after which the `search-forward` bound would be wrongly calculated.