### PR TITLE
evil-core: refactored  `evil-get-auxiliary-keymap`

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -871,8 +871,7 @@ one already."
   (when state
     (let* ((key (vconcat (list (intern (format "%s-state" state)))))
            (parent-aux (when (and ignore-parent
-                                  (keymap-parent map)
-                                  state)
+                                  (keymap-parent map))
                          (lookup-key (keymap-parent map) key)))
            (aux (lookup-key map key)))
       (cond

--- a/evil-core.el
+++ b/evil-core.el
@@ -874,7 +874,7 @@ one already."
                                   (keymap-parent map)
                                   state)
                          (lookup-key (keymap-parent map) key)))
-           (aux (if state (lookup-key map key) map)))
+           (aux (lookup-key map key)))
       (cond
        ((and ignore-parent
              (equal parent-aux aux)


### PR DESCRIPTION
In `evil-get-auxilliary-keymap`, there's already a check on `state` when entering the function.
Should `state` be `nil`, it won't enter the `let*` form.

The binding specification
`(aux (if state (lookup-key map key) map))`
always reduces to
`(aux (lookup-key map key))`

And `(parent-aux (when (and ignore-parent (keymap-parent map) state)))`
always reduces to
`(parent-aux (when (and ignorant-parent (keymap-parent map))))`

This commit removed unnecessary `if` form, and removed redundant `state` in `and` form, as described above.