### PR TITLE
evil-maybe-remove-spaces works for evil-change-line

### DIFF
--- a/evil-states.el
+++ b/evil-states.el
@@ -99,6 +99,8 @@ commands opening a new line."
                  evil-open-below
                  evil-append
                  evil-append-line
+                 evil-change
+                 evil-change-line
                  newline
                  newline-and-indent
                  indent-and-newline)))

--- a/evil-states.el
+++ b/evil-states.el
@@ -101,6 +101,7 @@ commands opening a new line."
                  evil-append-line
                  evil-change
                  evil-change-line
+                 evil-change-whole-line
                  newline
                  newline-and-indent
                  indent-and-newline)))


### PR DESCRIPTION
This change make `cc` + `ESC` on indented line produce the same behavior
as vim/nvim