### PR TITLE
Add [return] to evil-repeat-info when recording for evil-ex-search

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3547,12 +3547,13 @@ resp.  after executing the command."
     (evil-repeat-record (this-command-keys))
     (evil-clear-command-keys))
    ((and (evil-operator-state-p) (eq flag 'post))
-    ;; The value of (this-command-keys) at this point should be the
-    ;; key-sequence that called the last command that finished the
-    ;; search, usually RET. Therefore this key-sequence will be
-    ;; recorded in the post-command of the operator. Alternatively we
-    ;; could do it here.
-    (evil-repeat-record (evil-ex-pattern-regex evil-ex-search-pattern)))
+    (evil-repeat-record (evil-ex-pattern-regex evil-ex-search-pattern))
+    ;; If it weren't for the fact that `exit-minibuffer' throws an `exit'
+    ;; tag, which bypasses the source of `this-command-keys', we'd be able
+    ;; to capture the key(s) in the post-command of the operator as usual.
+    ;; Fortunately however, `last-input-event' can see the key (by default, `return')
+    (unless (append (this-command-keys) nil)
+      (evil-repeat-record (vector last-input-event))))
    (t (evil-repeat-motion flag))))
 
 (evil-define-motion evil-ex-search-forward (count)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7608,6 +7608,16 @@ maybe we need one line more with some text\n"
         ("n")
         "(defun my-symbol-func ())\n(defvar my-symbol-var)\n(my-symbol-func)\n(setq my-symbol-func2 ([m]y-symbol-func))\n"))))
 
+(ert-deftest evil-test-ex-search-motion ()
+  :tags '(evil ex search)
+  (evil-without-display
+    (evil-select-search-module 'evil-search-module 'evil-search)
+    (ert-info ("Ex forward search, as a motion, can be repeated")
+      (evil-test-buffer
+        "alpha [b]ravo charlie delta golf hotel charlie india"
+        ("c/charlie" [return] "replacement " [escape] "4w.")
+        "alpha replacement charlie delta golf replacement[ ]charlie india"))))
+
 (ert-deftest evil-test-isearch-word ()
   "Test isearch for word under point."
   :tags '(evil isearch)


### PR DESCRIPTION
Interestingly, this isn't necessary in emacs 25 and earlier. Hence the `unless` test. I'm not sure if this is a bug introduced after emacs 25.