### PR TITLE
Use text scale in calculating visible window height

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1043,7 +1043,7 @@ If the scroll count is zero the command scrolls half the screen."
     (when (= (point-min) (line-beginning-position))
       (signal 'beginning-of-buffer nil))
     (when (zerop count)
-      (setq count (/ (window-body-height) 2)))
+      (setq count (/ (evil-window-visible-height) 2)))
     (let ((xy (evil-posn-x-y (posn-at-point))))
       (condition-case nil
           (progn
@@ -1067,7 +1067,7 @@ If the scroll count is zero the command scrolls half the screen."
     (setq evil-scroll-count count)
     (when (eobp) (signal 'end-of-buffer nil))
     (when (zerop count)
-      (setq count (/ (window-body-height) 2)))
+      (setq count (/ (evil-window-visible-height) 2)))
     ;; BUG #660: First check whether the eob is visible.
     ;; In that case we do not scroll but merely move point.
     (if (<= (point-max) (window-end))

--- a/evil-common.el
+++ b/evil-common.el
@@ -3980,6 +3980,18 @@ PROPERTIES is a property-list which supports the following properties:
          (evil-motion-state))
        (switch-to-buffer-other-window buf))))
 
+;;; Window
+
+(defun evil-window-visible-height (&optional window)
+  "The visible height of WINDOW in lines.
+
+If no WINDOW is specified, use the selected one."
+  (let ((window (or window (selected-window))))
+    (save-window-excursion
+      (select-window window)
+      (let ((current-scale (expt text-scale-mode-step text-scale-mode-amount)))
+        (round (/ (window-body-height) current-scale))))))
+
 (provide 'evil-common)
 
 ;;; evil-common.el ends here


### PR DESCRIPTION
Fixes #1497 

@tomdl89 your idea to use text scale works perfectly. Initially I did think it was over-reporting the window height, but upon closer inspection, it is reporting the total number of visible _lines of text_, not _lines of code_, which is exactly what we are looking for, and matches Vim behavior as well as far as I was able to check.

To test:
1. create a buffer with single words, e.g. 100ihello<RET><esc>
2. now check `(evil-window-visible-height)` at different zoom levels. It should report the correct value
3. create a buffer with long lines, e.g. 20ihello<space><RET><esc> along with other, regular-length lines
4. now check `(evil-window-visible-height)` again. It will show a larger number than what is actually displayed in line numbers on the screen.
5. Looking at the line number column (e.g. `global-display-line-numbers-mode`), count the number of blanks between line numbers. These are lines that are actually displayed, but which do not correspond to line numbers because the lines are wrapped. Add this number to the visible number and you should get the number reported by `evil-window-visible-height`.

Looking at the behavior in Vim, I wasn't able to detect a difference at different zoom levels, or at the end of the buffer.
 
cc @chopptimus - please let us know if you have a chance to verify the fix and notice any other differences 🙏 
