### PR TITLE
Allow overriding/intercepting multiple states

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -928,6 +928,8 @@ If STATE is nil, it means any state."
       map)
      ((eq entry state)
       map)
+     ((and (listp entry) (member state entry))
+      map)
      ((eq entry 'all)
       map))))
 
@@ -944,6 +946,8 @@ If STATE is nil, it means any state."
      ((null state)
       map)
      ((eq entry state)
+      map)
+     ((and (listp entry) (member state entry))
       map)
      ((eq entry 'all)
       map))))


### PR DESCRIPTION
Sometimes I need to set overriding keymap, neither for any specific state or all states, but some states(such as only normal and visual states), this would be useful then. 