### PR TITLE
Add `evil-search-wrap-ring-bell` customization variable

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -264,8 +264,10 @@ one more than the current position."
       ;; determine message for echo area
       (cond
        ((and forward (< (point) start))
+        (when evil-search-wrap-ring-bell (ding))
         (setq string "Search wrapped around BOTTOM of buffer"))
        ((and (not forward) (> (point) start))
+        (when evil-search-wrap-ring-bell (ding))
         (setq string "Search wrapped around TOP of buffer"))
        (t
         (setq string (evil-search-message string forward))))

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -599,6 +599,11 @@ in insert state."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-search-wrap-ring-bell nil
+  "Whether to ring the bell when search wraps around the buffer."
+  :type  'boolean
+  :group 'evil)
+
 (defvar dabbrev-search-these-buffers-only)
 (defvar dabbrev-case-distinction)
 (defcustom evil-complete-next-func


### PR DESCRIPTION
I tend to miss when `evil-search` wraps around the buffer. Ringing the bell combined with `visible-bell` makes it much more obvious to me than just the text in the echo area.

`isearch` also rings the bell when it wraps.