### PR TITLE
use evil motion state for builtin emacs completion lists

### DIFF
--- a/evil-keybindings.el
+++ b/evil-keybindings.el
@@ -46,7 +46,15 @@
 
 ;;; Buffer-menu
 
-(evil-add-hjkl-bindings Buffer-menu-mode-map 'motion)
+(evil-add-hjkl-bindings Buffer-menu-mode-map 'motion
+  (kbd "RET") 'Buffer-menu-select)
+
+
+;;; completion-list
+
+(evil-add-hjkl-bindings completion-list-mode-map 'motion
+  (kbd "TAB") 'next-completion
+  (kbd "RET") 'choose-completion)
 
 ;; dictionary.el
 

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -877,6 +877,7 @@ expression matching the buffer's name and STATE is one of `normal',
 (defcustom evil-motion-state-modes
   '(apropos-mode
     Buffer-menu-mode
+    completion-list-mode
     calendar-mode
     color-theme-mode
     command-history-mode


### PR DESCRIPTION
making default emacs completion lists use evil motion state