### PR TITLE
Add missing company function to `evil-repeat` list

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -215,7 +215,8 @@
            '(company-complete-mouse
              company-complete-number
              company-complete-selection
-             company-complete-common))
+             company-complete-common
+             company-complete-common-or-cycle))
 
      (mapc #'evil-declare-ignore-repeat
            '(company-abort


### PR DESCRIPTION
Added [`company-complete-common-or-cycle`](https://github.com/company-mode/company-mode/blob/3eaac91b27d5041a97a0cbae32bb5b03e361d230/company.el#L2575) to the list of function for company in `evil-repeat` integration.