### PR TITLE
Fix for #1518

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -234,19 +234,6 @@ move COUNT - 1 screen lines downward first."
                        -1
                        (/ (with-no-warnings (window-body-width)) 2)))))
 
-(evil-define-motion evil-beginning-of-line-or-digit-argument ()
-  "Move the cursor to the beginning of the current line.
-This function passes its command to `digit-argument' (usually a 0)
-if it is not the first event."
-  :type exclusive
-  (cond
-   (current-prefix-arg
-    (setq this-command #'digit-argument)
-    (call-interactively #'digit-argument))
-   (t
-    (setq this-command #'evil-beginning-of-line)
-    (call-interactively #'evil-beginning-of-line))))
-
 (evil-define-motion evil-first-non-blank ()
   "Move the cursor to the first non-blank character of the current line."
   :type exclusive

--- a/evil-common.el
+++ b/evil-common.el
@@ -555,7 +555,7 @@ Both COUNT and CMD may be nil."
                                    (list (car cmd) (* (or count 1)
                                                       (or (cadr cmd) 1))))))))
                ((or (eq cmd #'digit-argument)
-                    (and (eq cmd 'evil-digit-argument-or-evil-beginning-of-line)
+                    (and (memq cmd evil-digit-bound-motions)
                          count))
                 (let* ((event (aref seq (- (length seq) 1)))
                        (char (or (when (characterp event) event)
@@ -741,31 +741,6 @@ recursively."
            (t ; append a further event
             (setq end (1+ end))))))
       (user-error "Key sequence contains no complete binding"))))
-
-(defmacro evil-redirect-digit-argument (map keys target)
-  "Bind a wrapper function calling TARGET or `digit-argument'.
-MAP is a keymap for binding KEYS to the wrapper for TARGET.
-The wrapper only calls `digit-argument' if a prefix-argument
-has already been started; otherwise TARGET is called."
-  (let* ((target (eval target))
-         (wrapper (intern (format "evil-digit-argument-or-%s"
-                                  target))))
-    `(progn
-       (define-key ,map ,keys ',wrapper)
-       (evil-define-command ,wrapper ()
-         :digit-argument-redirection ,target
-         :keep-visual t
-         :repeat nil
-         (interactive)
-         (cond
-          (current-prefix-arg
-           (setq this-command #'digit-argument)
-           (call-interactively #'digit-argument))
-          (t
-           (let ((target (or (command-remapping #',target)
-                             #',target)))
-             (setq this-command target)
-             (call-interactively target))))))))
 
 (defun evil-extract-append (file-or-append)
   "Return an (APPEND . FILENAME) pair based on FILE-OR-APPEND.

--- a/evil-common.el
+++ b/evil-common.el
@@ -723,8 +723,7 @@ recursively."
            ((functionp cmd)
             (if (or (memq cmd '(digit-argument negative-argument))
                     (and found-prefix
-                         (evil-get-command-property
-                          cmd :digit-argument-redirection)))
+                         (memq cmd evil-digit-bound-motions)))
                 ;; skip those commands
                 (setq found-prefix t ; found at least one prefix argument
                       beg end

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -476,25 +476,13 @@ Based on `evil-enclose-ace-jump-for-motion'."
 
 ;; visual-line-mode integration
 (when evil-respect-visual-line-mode
-  (evil-define-command evil-digit-argument-or-evil-beginning-of-visual-line ()
-    :digit-argument-redirection evil-beginning-of-visual-line
-    :keep-visual t
-    :repeat nil
-    (interactive)
-    (cond
-     (current-prefix-arg
-      (setq this-command #'digit-argument)
-      (call-interactively #'digit-argument))
-     (t
-      (setq this-command 'evil-beginning-of-visual-line)
-      (call-interactively 'evil-beginning-of-visual-line))))
-
+  (customize-set-variable 'evil-digit-bound-motions '(evil-beginning-of-visual-line))
   (evil-define-minor-mode-key 'motion 'visual-line-mode
     "j" 'evil-next-visual-line
     "gj" 'evil-next-line
     "k" 'evil-previous-visual-line
     "gk" 'evil-previous-line
-    "0" 'evil-digit-argument-or-evil-beginning-of-visual-line
+    "0" 'evil-beginning-of-visual-line
     "g0" 'evil-beginning-of-line
     "$" 'evil-end-of-visual-line
     "g$" 'evil-end-of-line

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -169,7 +169,7 @@
 ;;; Motion state
 
 ;; "0" is a special command when called first
-(evil-redirect-digit-argument evil-motion-state-map "0" 'evil-beginning-of-line)
+(define-key evil-motion-state-map "0" 'evil-beginning-of-line)
 (define-key evil-motion-state-map "1" 'digit-argument)
 (define-key evil-motion-state-map "2" 'digit-argument)
 (define-key evil-motion-state-map "3" 'digit-argument)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -1605,7 +1605,7 @@ New Tex[t]
     (ert-info ("Treat 0 as a motion")
       (should (equal
                (evil-keypress-parser '(?0))
-               '(evil-digit-argument-or-evil-beginning-of-line nil))))
+               '(evil-beginning-of-line nil))))
     (ert-info ("Handle keyboard macros")
       (evil-test-buffer
         (define-key evil-motion-state-local-map (kbd "W") (kbd "w"))
@@ -8455,12 +8455,12 @@ Source
 
     (ert-info ("Exact \"0\" count")
       (should (equal (evil-extract-count "0")
-                     (list nil 'evil-digit-argument-or-evil-beginning-of-line
+                     (list nil 'evil-beginning-of-line
                            "0" nil))))
 
     (ert-info ("Extra elements and \"0\"")
       (should (equal (evil-extract-count "0XY")
-                     (list nil 'evil-digit-argument-or-evil-beginning-of-line
+                     (list nil 'evil-beginning-of-line
                            "0" "XY"))))
 
     (ert-info ("Count only")

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -604,6 +604,15 @@ in insert state."
   :type  'boolean
   :group 'evil)
 
+(defcustom evil-digit-bound-motions
+  '(evil-beginning-of-line)
+  "The motion commands that can be bound to some digit key (typically 0).
+While Evil is reading a motion command, functions in this list act as themselves
+if their corresponding key was the first digit in the key sequence, and behave
+like `digit-argument' for the purposes of `evil-keypress-parser' otherwise."
+  :type '(repeat function)
+  :group 'evil)
+
 (defvar dabbrev-search-these-buffers-only)
 (defvar dabbrev-case-distinction)
 (defcustom evil-complete-next-func


### PR DESCRIPTION
This PR gets rid of `evil-redirect-digit-argument`, and replaces its effects with a custom variable. The variable is a list of functions that can be bound to digits (always 0 in practice, I'd imagine, but I'm sure [someone's workflow](https://xkcd.com/1172/) would be affected). This allows for greater consistency in how functions can be bound to 0 - just use any of the `define-key` variants like normal, then add the relevant function to the custom variable, instead of binding with `evil-redirect-digit-argument`.

It passes all tests, except for the ones that explicitly rely on "0" being bound to the wrapper function for `evil-beginning-of-line`, which I've fixed.

One thing I'd like feedback on is that I don't like the way that the new `evil-digit-bound-motions` custom variable is set with `customize-set-variable` when `evil-respect-visual-line-mode` is enabled. Since I typically `setq` custom variables in my init.el instead of using a custom file, I don't know if setting this one programmatically will cause issues in general.

This PR also removes `evil-beginning-of-line-or-digit-argument`, since it hasn't been touched since 2011.