### PR TITLE
Add option for non-incremental search (#1304)

### DIFF
--- a/doc/source/settings.rst
+++ b/doc/source/settings.rst
@@ -81,6 +81,8 @@ Search
 
 .. elisp:autovariable:: evil-ex-hl-update-delay
 
+.. elisp:autovariable:: evil-ex-search-incremental
+
 
 Indentation
 -----------

--- a/evil-search.el
+++ b/evil-search.el
@@ -892,7 +892,8 @@ message to be shown. This function does nothing if
 (defun evil-ex-search-start-session ()
   "Initialize Ex for interactive search."
   (remove-hook 'minibuffer-setup-hook #'evil-ex-search-start-session)
-  (add-hook 'after-change-functions #'evil-ex-search-update-pattern nil t)
+  (when evil-ex-search-incremental
+    (add-hook 'after-change-functions #'evil-ex-search-update-pattern nil t))
   (add-hook 'minibuffer-exit-hook #'evil-ex-search-stop-session)
   (add-hook 'mouse-leave-buffer-hook #'evil-ex-search-exit)
   (evil-ex-search-activate-highlight nil))
@@ -1137,7 +1138,9 @@ current search result."
                   evil-ex-search-match-end (match-end 0))
             (evil-ex-search-goto-offset offset)
             (evil-push-search-history search-string (eq direction 'forward))
-            (unless evil-ex-search-persistent-highlight
+            (when (and (not evil-ex-search-incremental) evil-ex-search-highlight-all)
+              (evil-ex-search-activate-highlight pattern))
+            (when (and evil-ex-search-incremental (not evil-ex-search-persistent-highlight))
               (evil-ex-delete-hl 'evil-ex-search)))
            (t
             (goto-char evil-ex-search-start-point)

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1224,6 +1224,12 @@ used."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-ex-search-incremental t
+  "If t, use incremental search. Note that this only affects the
+search command if `evil-search-module' is set to 'evil-search."
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-ex-search-highlight-all t
   "If t and interactive search is enabled, all matches are
 highlighted."


### PR DESCRIPTION
This adds non-incremental search capability to evil, similar to vim/neovim's "set noincsearch" option.  Only needs a few lines of code change.

It adds a custom var ```evil-ex-search-incremental``` which defaults to t, but can be set to nil to activate non-incremental search (only if ```evil-search``` module is used.)

Fixes #1304.