### PR TITLE
Fix #1518: "custom functions bound to '0' break motion parsing" in a saner way

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -555,7 +555,7 @@ Both COUNT and CMD may be nil."
                                    (list (car cmd) (* (or count 1)
                                                       (or (cadr cmd) 1))))))))
                ((or (eq cmd #'digit-argument)
-                    (and (memq cmd evil-digit-bound-motions)
+                    (and (equal seq "0")
                          count))
                 (let* ((event (aref seq (- (length seq) 1)))
                        (char (or (when (characterp event) event)
@@ -723,7 +723,8 @@ recursively."
            ((functionp cmd)
             (if (or (memq cmd '(digit-argument negative-argument))
                     (and found-prefix
-                         (memq cmd evil-digit-bound-motions)))
+                         (or (equal (substring keys beg end) "0")
+                             (equal (substring keys beg end) [48]))))
                 ;; skip those commands
                 (setq found-prefix t ; found at least one prefix argument
                       beg end

--- a/evil-common.el
+++ b/evil-common.el
@@ -724,7 +724,7 @@ recursively."
            ((functionp cmd)
             (if (or (memq cmd '(digit-argument negative-argument))
                     (and found-prefix
-                         (equal (vconcat seq) [48])))
+                         (equal (vconcat seq) (vector ?0))))
                 ;; skip those commands
                 (setq found-prefix t ; found at least one prefix argument
                       beg end

--- a/evil-common.el
+++ b/evil-common.el
@@ -710,10 +710,11 @@ recursively."
            (end 1)
            (found-prefix nil))
       (while (and (<= end len))
-        (let ((cmd (key-binding (substring keys beg end))))
+        (let* ((seq (substring keys beg end))
+               (cmd (key-binding seq)))
           (cond
            ((memq cmd '(undefined nil))
-            (user-error "No command bound to %s" (substring keys beg end)))
+            (user-error "No command bound to %s" seq))
            ((arrayp cmd) ; keyboard macro, replace command with macro
             (setq keys (vconcat (substring keys 0 beg)
                                 cmd
@@ -723,8 +724,7 @@ recursively."
            ((functionp cmd)
             (if (or (memq cmd '(digit-argument negative-argument))
                     (and found-prefix
-                         (or (equal (substring keys beg end) "0")
-                             (equal (substring keys beg end) [48]))))
+                         (equal (vconcat seq) [48])))
                 ;; skip those commands
                 (setq found-prefix t ; found at least one prefix argument
                       beg end
@@ -735,7 +735,7 @@ recursively."
                              (string-to-number
                               (concat (substring keys 0 beg))))
                            cmd
-                           (substring keys beg end)
+                           seq
                            (when (< end len)
                              (substring keys end))))))
            (t ; append a further event

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -476,7 +476,6 @@ Based on `evil-enclose-ace-jump-for-motion'."
 
 ;; visual-line-mode integration
 (when evil-respect-visual-line-mode
-  (customize-set-variable 'evil-digit-bound-motions '(evil-beginning-of-visual-line))
   (evil-define-minor-mode-key 'motion 'visual-line-mode
     "j" 'evil-next-visual-line
     "gj" 'evil-next-line

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -611,15 +611,6 @@ in insert state."
   :type  'boolean
   :group 'evil)
 
-(defcustom evil-digit-bound-motions
-  '(evil-beginning-of-line)
-  "The motion commands that can be bound to some digit key (typically 0).
-While Evil is reading a motion command, functions in this list act as themselves
-if their corresponding key was the first digit in the key sequence, and behave
-like `digit-argument' for the purposes of `evil-keypress-parser' otherwise."
-  :type '(repeat function)
-  :group 'evil)
-
 (defvar dabbrev-search-these-buffers-only)
 (defvar dabbrev-case-distinction)
 (defcustom evil-complete-next-func


### PR DESCRIPTION
This PR improves on #1519, which I made about a week ago. I'm pretty new to Emacs development, so when I made those changes I was imagining some graybeard poweruser with way more experience than me, willfully rebinding digit keys besides "0" to bizarre functions. However, after some reflection I imagine that this is such a rare use case that it isn't really necessary to support it. By way of explanation:

In Vim/Evil, we know that if "0" is the first number we see in a sequence, we should treat it as a motion, because e.g. "d010j" is meaningless - you could just write "d10j". There will never be a case where "0" is *both* the first digit in a sequence *and* has meaning as a number, so when we see a "0" at the beginning of a sequence we're always safe to treat it as a motion instead of part of a count argument.

The variable I added in the *last* PR would allow this behavior with other digits: e.g. "d1" could be a valid and complete command, but you'd also still be able to have "d31j" do as you expect. This comes with the caveat that you *wouldn't* be able to do "d15j" for instance.

In hindsight, this really doesn't make much sense. People do wild stuff with Emacs - I'm sure there's *someone* who would put that facility to good use. However, I imagine it happens infrequently enough that we shouldn't make a special variable just to handle that case, and summarily force people that want to bind functions to "0" to discover and mess with a custom variable, just to accommodate that one weird graybeard.

This PR (instead of checking for a function's inclusion in a list of motions bound to digit keys) simply checks if an entered key is "0" and decides intelligently if its corresponding function should be treated as a digit argument or as a motion. This means that you can bind motions to 0 completely transparently, just like with any other key - no need for weird `evil-redirect-digit-argument` shenanigans (which didn't work), or the additional overhead of adding the function to a custom variable (blech).

In summary, as far as binding stuff to digits goes:

| Strategy | Does it work? | Allows binding to digits besides 0? | 0 motions defined the same as other keybinds? |
| --- | --- | --- | --- |
| `evil-redirect-digit-argument` | :x: | :x: | :x: |
| `evil-digit-bound-motions` | :heavy_check_mark: | :heavy_check_mark: | :x: |
| This PR | :heavy_check_mark: | :x: | :heavy_check_mark: |