### PR TITLE
Add option of stop updating X PRIMARY selection with the current visual region

### DIFF
--- a/doc/docstringdb.json
+++ b/doc/docstringdb.json
@@ -17052,5 +17052,16 @@
     "functionp": true,
     "macrop": null,
     "keymap-inv": null
+  },
+  "evil-visual-update-x-selection-p": {
+    "default": "t",
+    "local": false,
+    "default-type": "symbol",
+    "var-docstring": "Whether to update the X PRIMARY selection with the current visual region automatically.",
+    "fn-docstring": null,
+    "arglist": true,
+    "functionp": null,
+    "macrop": null,
+    "keymap-inv": null
   }
 }

--- a/doc/docstringdb.json
+++ b/doc/docstringdb.json
@@ -17052,16 +17052,5 @@
     "functionp": true,
     "macrop": null,
     "keymap-inv": null
-  },
-  "evil-visual-update-x-selection-p": {
-    "default": "t",
-    "local": false,
-    "default-type": "symbol",
-    "var-docstring": "Whether to update the X PRIMARY selection with the current visual region automatically.",
-    "fn-docstring": null,
-    "arglist": true,
-    "functionp": null,
-    "macrop": null,
-    "keymap-inv": null
   }
 }

--- a/evil-states.el
+++ b/evil-states.el
@@ -364,16 +364,17 @@ otherwise exit Visual state."
 (put 'evil-visual-post-command 'permanent-local-hook t)
 
 (defun evil-visual-update-x-selection (&optional buffer)
-  "Update the X selection with the current visual region."
-  (let ((buf (or buffer (current-buffer))))
-    (when (buffer-live-p buf)
-      (with-current-buffer buf
-        (when (and (evil-visual-state-p)
-                   (display-selections-p)
-                   (not (eq evil-visual-selection 'block)))
-          (evil-set-selection 'PRIMARY (buffer-substring-no-properties
-                                        evil-visual-beginning
-                                        evil-visual-end)))))))
+  "Update the X selection with the current visual region of BUFFER."
+  (when evil-visual-update-x-selection-p
+    (let ((buf (or buffer (current-buffer))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (when (and (evil-visual-state-p)
+                     (display-selections-p)
+                     (not (eq evil-visual-selection 'block)))
+            (evil-set-selection 'PRIMARY (buffer-substring-no-properties
+                                          evil-visual-beginning
+                                          evil-visual-end))))))))
 
 (defun evil-visual-activate-hook (&optional _command)
   "Enable Visual state if the region is activated."

--- a/evil-states.el
+++ b/evil-states.el
@@ -365,16 +365,16 @@ otherwise exit Visual state."
 
 (defun evil-visual-update-x-selection (&optional buffer)
   "Update the X selection with the current visual region of BUFFER."
-  (when evil-visual-update-x-selection-p
-    (let ((buf (or buffer (current-buffer))))
-      (when (buffer-live-p buf)
-        (with-current-buffer buf
-          (when (and (evil-visual-state-p)
-                     (display-selections-p)
-                     (not (eq evil-visual-selection 'block)))
-            (evil-set-selection 'PRIMARY (buffer-substring-no-properties
-                                          evil-visual-beginning
-                                          evil-visual-end))))))))
+  (let ((buf (or buffer (current-buffer))))
+    (when (and evil-visual-update-x-selection-p
+               (buffer-live-p buf)
+               (evil-visual-state-p)
+               (display-selections-p)
+               (not (eq evil-visual-selection 'block)))
+      (with-current-buffer buf
+        (evil-set-selection 'PRIMARY (buffer-substring-no-properties
+                                      evil-visual-beginning
+                                      evil-visual-end))))))
 
 (defun evil-visual-activate-hook (&optional _command)
   "Enable Visual state if the region is activated."

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -2038,6 +2038,11 @@ to `undo-redo', Evil uses commands natively available in Emacs 28."
            (evil-set-undo-system value)
            (set-default sym value)))
 
+(defcustom evil-visual-update-x-selection-p t
+  "Whether to update the X PRIMARY selection with the current visual region automatically."
+  :type  'boolean
+  :group 'evil)
+
 (defun evil-version ()
   (interactive)
   (message "Evil version %s" evil-version))


### PR DESCRIPTION
Vim user can select a region in visual mode and press the key `p` to
replace the selected text.

But in GUI Emacs, the selected text won't be replaced because the commands
in visual state automatically insert the selected text into the X selection.
Press key `p` or run `evil-paste-after` only copies from the X selection which
is same as the selected text.

Console Emacs does not have this problem.