### PR TITLE
Fix #1541: Advice point for kill-sexp in normal/visual mode

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -260,6 +260,7 @@
       (apply command args)))
 
   (advice-add 'elisp--preceding-sexp :around 'evil--preceding-sexp '((name . evil)))
+  (advice-add 'kill-sexp             :around 'evil--preceding-sexp '((name . evil)))
   (advice-add 'pp-last-sexp          :around 'evil--preceding-sexp '((name . evil)))))
 
 ;; Show key


### PR DESCRIPTION
Added advice for `kill-sexp` based on the existing functions. 

That fix works fine for me a while already.