### PR TITLE
Make `evil-record-macro' add the same macro to the kmacro ring

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2276,7 +2276,7 @@ The return value is the yanked text."
   "The buffer that has been active on macro recording.")
 
 (defun evil-end-and-return-macro ()
-  "Like `end-kbd-macro' but also return the macro.
+  "Like `kmacro-end-macro' but also return the macro.
 Remove \\<evil-insert-state-map>\\[evil-execute-in-normal-state] from the end."
   (kmacro-end-macro nil)
   (let ((end-keys-seq (append evil-execute-normal-keys nil))

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2278,7 +2278,7 @@ The return value is the yanked text."
 (defun evil-end-and-return-macro ()
   "Like `end-kbd-macro' but also return the macro.
 Remove \\<evil-insert-state-map>\\[evil-execute-in-normal-state] from the end."
-  (end-kbd-macro)
+  (kmacro-end-macro nil)
   (let ((end-keys-seq (append evil-execute-normal-keys nil))
         (last-kbd-macro-seq (append last-kbd-macro nil)))
     (unless last-kbd-macro-seq
@@ -2320,7 +2320,7 @@ will be opened instead."
       (when defining-kbd-macro (end-kbd-macro))
       (setq evil-this-macro register)
       (evil-set-register evil-this-macro nil)
-      (start-kbd-macro nil)
+      (kmacro-start-macro nil)
       (setq evil-macro-buffer (current-buffer)))
      (t (error "Invalid register")))))
 


### PR DESCRIPTION
Sorry, but this is the same as #1064.
#1064 was forked from a very old code, so I opened a new pull request while updating it, so please take a look.

This allows kmacro to edit macros independently of the original evil macro.

Update is,
1. Add the same macro recorded as `evil-record-macro` to the kmacro ring.
2. Make the added kmacro editable

This simply adds the same macro to the kmacro ring and allows the user to edit it(without touching original evil macro). So I believe this update will not break the workflow for existing evil users.

Thank you.