### PR TITLE
Allow parsing of js arrow fn `=>` in xml tags

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1559,7 +1559,7 @@ last successful match (that caused COUNT to reach zero)."
         (while
             (and (setq match
                        (re-search-forward
-                        "<\\([^/ >\n]+\\)\\(?:[^\"/>]\\|\"[^\"]*\"\\)*?>\\|</\\([^>]+?\\)>"
+                        "<\\([^/ >\n]+\\)\\(?:=>?\\|[^\"/>]\\|\"[^\"]*\"\\)*?>\\|</\\([^>]+?\\)>"
                         nil t dir))
                  (cond
                   ((match-beginning op)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -6922,9 +6922,14 @@ test hello <a href=\"/deed.zh\">Creative Commons</a>
 </p>[\n]}</div>
 </body>
 </html>
-"
-
-      )))
+"))
+  (ert-info ("Handle js arrow fns")
+    (evil-test-buffer
+      :visual-start "«"
+      :visual-end "»"
+      "<button foo=\"bar\" onClick={() => fnbody()}>inner [t]ext</button>"
+      ("vit")
+      "<button foo=\"bar\" onClick={() => fnbody()}>«inner tex[t]»</button>")))
 
 ;;; Visual state
 


### PR DESCRIPTION
fixes #1572 