### PR TITLE
evil-fold-action: add missing FORMAT argument to with-demoted-errors

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3065,7 +3065,7 @@ not interfere with another."
           (let* ((actions (cdar list))
                  (fn      (plist-get actions action)))
             (when fn
-              (with-demoted-errors (funcall fn))))
+              (with-demoted-errors "Error: %S" (funcall fn))))
         (evil-fold-action (cdr list) action)))))
 
 (defun evil--mode-p (modes)


### PR DESCRIPTION
See issue https://github.com/emacs-evil/evil/issues/1585

* evil-commands.el (evil-fold-action): add FORMAT argument which is now required as of Emacs commit d52c929e31f60ff0462371bfe27ebd479e3e82bd.