### PR TITLE
evil-ex-make-pattern: Don't transform the word boundaries into vim-style

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -434,7 +434,9 @@ expression and is not transformed."
         (ignore-case (eq (evil-ex-regex-case regexp case) 'insensitive)))
     ;; possibly transform regular expression from vim-style to
     ;; Emacs-style.
-    (if evil-ex-search-vim-style-regexp
+    (if (and evil-ex-search-vim-style-regexp
+             (not (or (string-match-p "\\`\\\\_?<" regexp)
+                      (string-match-p "\\\\_?>\\'" regexp))))
         (setq re (evil-transform-vim-style-regexp re))
       ;; Even for Emacs regular expressions we translate certain
       ;; whitespace sequences

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7952,9 +7952,11 @@ maybe we need one line more with some text\n"
       (let ((evil-ex-search-vim-style-regexp t)
             (evil-magic 'very-magic))
         (evil-test-buffer
-          "[a]lpha bravo alpha charlie"
+          "[a]lpha bravo alpha charlie alpha"
           ("*")
-          "alpha bravo [a]lpha charlie")))))
+          "alpha bravo [a]lpha charlie alpha"
+          ("/" [return])
+          "alpha bravo alpha charlie [a]lpha")))))
 
 (ert-deftest evil-test-ex-search-motion ()
   :tags '(evil ex search)


### PR DESCRIPTION
If very magic is enabled, the `"\\_<pattern\\_>"` will be transformed into `"\\_\\<pattern\\_\\>"`:

![image](https://user-images.githubusercontent.com/2653486/161375059-878f6ccf-a1f9-441d-afee-7bb764b79e73.png)

Minimal configuration to reproduce:

```elisp
emacs -Q -L ~/repos/emacs-evil --eval "
  (progn
    (toggle-debug-on-error)
    (require 'evil)
    (setq evil-magic 'very-magic)
    (setq evil-ex-search-vim-style-regexp t)
    (evil-select-search-module 'evil-search-module 'evil-search)
    (evil-mode 1)
    (with-current-buffer \"*scratch*\"
      (erase-buffer)
      (insert \"foo bar\nfoo bar\nfoo bar\nfoo bar\nfoo bar\nfoo bar\n\")
      (insert \"\nReproduce: \n\n  Press / and RET to repeat the last search.\")
      (goto-char (point-min))
      (evil-ex-start-word-search nil 'forward 1 t)
      (evil-ex-nohighlight)))
  " -nw
```