### PR TITLE
Exclude final empty line from implicit inclusion in substitution

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3826,13 +3826,17 @@ reveal.el. OPEN-SPOTS is a local version of `reveal-open-spots'."
                         (string-match-p "\n" (buffer-substring-no-properties
                                               match-beg match-end)))
                   (setq zero-length-match (= match-beg match-end))
-                  (when (and (string= "^" evil-ex-substitute-regex)
-                             (= (point) end-marker))
+                  (when (= match-end end-marker)
                     ;; The range (beg end) includes the final newline which means
-                    ;; end-marker is on one line down. With the regex "^" the
-                    ;; beginning of this last line will be matched which we don't
-                    ;; want, so we abort here.
-                    (throw 'exit-search t))
+                    ;; end-marker is on one line down, causing some issues...
+                    (when (and (not match-contains-newline) (bolp))
+                      ;; With the exception of explicitly substituting newlines,
+                      ;; we abort when the match ends here and it's an empty line
+                      (throw 'exit-search t))
+                    (when (string= "^" evil-ex-substitute-regex)
+                      ;; With the regex "^" the beginning of this last line
+                      ;; will be matched which we don't want, so we abort here
+                      (throw 'exit-search t)))
                   (setq evil-ex-substitute-last-point match-beg)
                   (if confirm
                       (let ((prompt

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7590,7 +7590,16 @@ echo foxtrot\ngolf hotel"
     (evil-test-buffer
       "[x]xyxxz"
       (":%s/x//g" [return])
-      "[y]z")))
+      "[y]z"))
+  (ert-info ("Substitute doesn't match final empty line")
+    (evil-test-buffer
+      "abc\n[d]ef\n\nghi"
+      (":s/$/4")
+      "abc\n[d]ef4\n\nghi")
+    (evil-test-buffer
+      "abc\n[d]ef\n\nghi"
+      (":s/f\\w*/4")
+      "abc\n[d]e4\n\nghi")))
 
 (ert-deftest evil-test-ex-repeat-substitute-replacement ()
   "Test `evil-ex-substitute' with repeating of previous substitutions."


### PR DESCRIPTION
Fixes #1321