### PR TITLE
New object approach

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1296,7 +1296,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-symbol (count &optional beg end type)
   "Select inner symbol."
-  (evil-select-inner-object 'evil-symbol beg end type count))
+  (evil-select-inner-unrestricted-object 'evil-symbol beg end type count))
 
 (evil-define-text-object evil-a-sentence (count &optional beg end type)
   "Select a sentence."
@@ -1304,7 +1304,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-sentence (count &optional beg end type)
   "Select inner sentence."
-  (evil-select-inner-object 'evil-sentence beg end type count))
+  (evil-select-inner-unrestricted-object 'evil-sentence beg end type count))
 
 (evil-define-text-object evil-a-paragraph (count &optional beg end type)
   "Select a paragraph."
@@ -1314,7 +1314,7 @@ or line COUNT to the top of the window."
 (evil-define-text-object evil-inner-paragraph (count &optional beg end type)
   "Select inner paragraph."
   :type line
-  (evil-select-inner-object 'evil-paragraph beg end type count t))
+  (evil-select-inner-unrestricted-object 'evil-paragraph beg end type count t))
 
 (evil-define-text-object evil-a-paren (count &optional beg end type)
   "Select a parenthesis."

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1280,7 +1280,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-word (count &optional beg end type)
   "Select inner word."
-  (evil-select-inner-object 'evil-word-object beg end type count))
+  (evil-select-inner-object 'evil-word beg end type count))
 
 (evil-define-text-object evil-a-WORD (count &optional beg end type)
   "Select a WORD."
@@ -1288,7 +1288,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-WORD (count &optional beg end type)
   "Select inner WORD."
-  (evil-select-inner-object 'evil-WORD-object beg end type count))
+  (evil-select-inner-object 'evil-WORD beg end type count))
 
 (evil-define-text-object evil-a-symbol (count &optional beg end type)
   "Select a symbol."

--- a/evil-common.el
+++ b/evil-common.el
@@ -3102,7 +3102,7 @@ This can be overridden with TYPE."
        (>= (evil-range-end range2)
            (evil-range-end range1))))
 
-(defun evil-select-inner-object (thing beg end type &optional count line)
+(defun evil-select-inner-unrestricted-object (thing beg end type &optional count line)
   "Return an inner text object range of COUNT objects.
 If COUNT is positive, return objects following point; if COUNT is
 negative, return objects preceding point.  If one is unspecified,
@@ -3131,6 +3131,20 @@ linewise, otherwise it is character wise."
                 (if (< count 0) end (point))
                 (if line 'line type)
                 :expanded t)))
+
+(defun evil-select-inner-object (thing beg end type &optional count line)
+  "Return an inner text object range of COUNT objects.
+Selection is restricted to the current line.
+If COUNT is positive, return objects following point; if COUNT is
+negative, return objects preceding point.  If one is unspecified,
+the other is used with a negative argument.  THING is a symbol
+understood by `thing-at-point'.  BEG, END and TYPE specify the
+current selection.  If LINE is non-nil, the text object should be
+linewise, otherwise it is character wise."
+  (save-restriction
+    (narrow-to-region (save-excursion (beginning-of-line) (point))
+                      (save-excursion (end-of-line) (point)))
+    (evil-select-inner-unrestricted-object thing beg end type count line)))
 
 (defun evil-select-an-object (thing beg end type count &optional line)
   "Return an outer text object range of COUNT objects.

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -5955,7 +5955,11 @@ Line 2"))
     (evil-test-buffer
       "foo\n  [ ]  bar"
       ("diW")
-      "foo\n[b]ar")))
+      "foo\n[b]ar")
+    (evil-test-buffer
+      "fo[o]\nbar"
+      ("diW")
+      "[\n]bar")))
 
 (ert-deftest evil-test-word-objects-cjk ()
   "Test `evil-inner-word' and `evil-a-word' on CJK words"


### PR DESCRIPTION
Revert `forward-evil-word` changes and new objects, in favour of a "restricted" form of `evil-select-inner-object`