### PR TITLE
Make sure not to test stale code

### DIFF
--- a/evil-tests.el
+++ b/evil-tests.el
@@ -61,6 +61,8 @@
 ;;
 ;; This file is NOT part of Evil itself.
 
+(setq load-prefer-newer t)
+
 (require 'cl-lib)
 (require 'elp)
 (require 'ert)


### PR DESCRIPTION
When there's outdate byte-compiled files, they may be loaded instead
of the new changed code.
Enable `load-prefer-newer` would avoid this.