### PR TITLE
Prevent setting a negative value for `temporary-goal-column`

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -993,8 +993,12 @@ so it is more compatible with evil's notions of eol & tracking."
            (debug t))
   (let ((normalize-temporary-goal-column
          `(if (consp temporary-goal-column)
-              (setq temporary-goal-column (+ (car temporary-goal-column)
-                                             (cdr temporary-goal-column))))))
+              ;; Ensure a negative value is never set for `temporary-goal-column'
+              ;; as it may have a negative component when both `whitespace-mode'
+              ;; and `display-line-numbers-mode' are enabled.
+              ;; See #1297
+              (setq temporary-goal-column (max 0 (+ (car temporary-goal-column)
+                                                    (cdr temporary-goal-column)))))))
     `(progn
        (unless evil-start-of-line (setq this-command 'next-line))
        ,normalize-temporary-goal-column


### PR DESCRIPTION
Fixes https://github.com/emacs-evil/evil/issues/1297

This is mostly a workaround for `temporary-goal-column` occasionally having negative values when both `whitespace-mode` and `display-line-numbers-mode` are enable. Without this change, `evil-ensure-column` would sometimes pass in negative values to `line-move-to-column` resulting in "line-move-to-column: Wrong type argument: wholenump, -5" errors.