### PR TITLE
update evil-quit to handle tabs

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -3329,7 +3329,7 @@ for the last window in each frame."
             wins))))
 
 (evil-define-command evil-quit (&optional force)
-  "Closes the current window, current frame, Emacs.
+  "Closes the current window, current frame, current tab, Emacs.
 If the current frame belongs to some client the client connection
 is closed."
   :repeat nil
@@ -3347,9 +3347,12 @@ is closed."
        (condition-case nil
            (delete-frame)
          (error
-          (if force
-              (kill-emacs)
-            (save-buffers-kill-emacs))))))))
+          (condition-case nil
+              (tab-bar-close-tab)
+            (error
+             (if force
+                 (kill-emacs)
+               (save-buffers-kill-emacs))))))))))
 
 (evil-define-command evil-quit-all (&optional bang)
   "Exits Emacs, asking for saving."


### PR DESCRIPTION
Closes #1624 

This PR updates `evil-quit` to properly handle tabs.

I think `tab-bar-close-tab` woud have been introduced in emacs 27, while evil supports emacs back to version 24. However, in this case we are already handling errors so this solution is still compatible with those versions. I couldn't come up with a clean way to use an `fboundp` here, and given it isn't strictly needed I omitted it, but I'm happy to take suggestions if there is a cleaner way to accomplish this. 