### PR TITLE
Small fix in 'evil-command-window-ex

### DIFF
--- a/evil-command-window.el
+++ b/evil-command-window.el
@@ -175,8 +175,7 @@ Parameters passed in through IGNORED are ignored."
 (defun evil-command-window-insert-commands (hist)
   "Insert the commands in HIST."
   (let ((inhibit-modification-hooks t))
-    (mapc #'(lambda (cmd) (insert cmd) (newline)) hist)
-    (reverse-region (point-min) (point-max)))
+    (mapc #'(lambda (cmd) (insert cmd) (newline)) (reverse hist)))
   (let ((prefix (propertize evil-command-window-cmd-key
                             'font-lock-face 'minibuffer-prompt)))
     (set-text-properties (point-min) (point-max) (list 'line-prefix prefix)))


### PR DESCRIPTION
No more "There are no full lines in the region" when the history is empty, and it is actually a small optimization since reverting lists is faster than reverting lines in a buffer.