### PR TITLE
Restore `evil-select-inner-object` API

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1280,7 +1280,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-word (count &optional beg end type)
   "Select inner word."
-  (evil-select-inner-object 'evil-word beg end type count))
+  (evil-select-inner-restricted-object 'evil-word beg end type count))
 
 (evil-define-text-object evil-a-WORD (count &optional beg end type)
   "Select a WORD."
@@ -1288,7 +1288,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-WORD (count &optional beg end type)
   "Select inner WORD."
-  (evil-select-inner-object 'evil-WORD beg end type count))
+  (evil-select-inner-restricted-object 'evil-WORD beg end type count))
 
 (evil-define-text-object evil-a-symbol (count &optional beg end type)
   "Select a symbol."
@@ -1296,7 +1296,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-symbol (count &optional beg end type)
   "Select inner symbol."
-  (evil-select-inner-unrestricted-object 'evil-symbol beg end type count))
+  (evil-select-inner-object 'evil-symbol beg end type count))
 
 (evil-define-text-object evil-a-sentence (count &optional beg end type)
   "Select a sentence."
@@ -1304,7 +1304,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-inner-sentence (count &optional beg end type)
   "Select inner sentence."
-  (evil-select-inner-unrestricted-object 'evil-sentence beg end type count))
+  (evil-select-inner-object 'evil-sentence beg end type count))
 
 (evil-define-text-object evil-a-paragraph (count &optional beg end type)
   "Select a paragraph."
@@ -1314,7 +1314,7 @@ or line COUNT to the top of the window."
 (evil-define-text-object evil-inner-paragraph (count &optional beg end type)
   "Select inner paragraph."
   :type line
-  (evil-select-inner-unrestricted-object 'evil-paragraph beg end type count t))
+  (evil-select-inner-object 'evil-paragraph beg end type count t))
 
 (evil-define-text-object evil-a-paren (count &optional beg end type)
   "Select a parenthesis."

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1276,7 +1276,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-a-word (count &optional beg end type)
   "Select a word."
-  (evil-select-an-object 'evil-word beg end type count))
+  (evil-select-a-restricted-object 'evil-word beg end type count))
 
 (evil-define-text-object evil-inner-word (count &optional beg end type)
   "Select inner word."
@@ -1284,7 +1284,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-a-WORD (count &optional beg end type)
   "Select a WORD."
-  (evil-select-an-object 'evil-WORD beg end type count))
+  (evil-select-a-restricted-object 'evil-WORD beg end type count))
 
 (evil-define-text-object evil-inner-WORD (count &optional beg end type)
   "Select inner WORD."
@@ -1292,7 +1292,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-a-symbol (count &optional beg end type)
   "Select a symbol."
-  (evil-select-an-unrestricted-object 'evil-symbol beg end type count))
+  (evil-select-an-object 'evil-symbol beg end type count))
 
 (evil-define-text-object evil-inner-symbol (count &optional beg end type)
   "Select inner symbol."
@@ -1300,7 +1300,7 @@ or line COUNT to the top of the window."
 
 (evil-define-text-object evil-a-sentence (count &optional beg end type)
   "Select a sentence."
-  (evil-select-an-unrestricted-object 'evil-sentence beg end type count))
+  (evil-select-an-object 'evil-sentence beg end type count))
 
 (evil-define-text-object evil-inner-sentence (count &optional beg end type)
   "Select inner sentence."
@@ -1309,7 +1309,7 @@ or line COUNT to the top of the window."
 (evil-define-text-object evil-a-paragraph (count &optional beg end type)
   "Select a paragraph."
   :type line
-  (evil-select-an-unrestricted-object 'evil-paragraph beg end type count t))
+  (evil-select-an-object 'evil-paragraph beg end type count t))
 
 (evil-define-text-object evil-inner-paragraph (count &optional beg end type)
   "Select inner paragraph."

--- a/evil-common.el
+++ b/evil-common.el
@@ -3153,7 +3153,7 @@ linewise, otherwise it is character wise."
                       (save-excursion (end-of-line) (point)))
     (evil-select-inner-object thing beg end type count line)))
 
-(defun evil-select-an-unrestricted-object (thing beg end type count &optional line)
+(defun evil-select-an-object (thing beg end type count &optional line)
   "Return an outer text object range of COUNT objects.
 If COUNT is positive, return objects following point; if COUNT is
 negative, return objects preceding point.  If one is unspecified,
@@ -3229,7 +3229,7 @@ linewise, otherwise it is character wise."
                 (if line 'line type)
                 :expanded t)))
 
-(defun evil-select-an-object (thing beg end type &optional count line)
+(defun evil-select-a-restricted-object (thing beg end type &optional count line)
   "Return an outer text object range of COUNT objects.
 Selection is restricted to the current line.
 If COUNT is positive, return objects following point; if COUNT is
@@ -3241,7 +3241,7 @@ linewise, otherwise it is character wise."
   (save-restriction
     (narrow-to-region (save-excursion (beginning-of-line) (point))
                       (save-excursion (end-of-line) (point)))
-    (evil-select-an-unrestricted-object thing beg end type count line)))
+    (evil-select-an-object thing beg end type count line)))
 
 (defun evil--get-block-range (op cl selection-type)
   "Return the exclusive range of a visual selection.

--- a/evil-common.el
+++ b/evil-common.el
@@ -3109,7 +3109,7 @@ This can be overridden with TYPE."
        (>= (evil-range-end range2)
            (evil-range-end range1))))
 
-(defun evil-select-inner-unrestricted-object (thing beg end type &optional count line)
+(defun evil-select-inner-object (thing beg end type &optional count line)
   "Return an inner text object range of COUNT objects.
 If COUNT is positive, return objects following point; if COUNT is
 negative, return objects preceding point.  If one is unspecified,
@@ -3139,7 +3139,7 @@ linewise, otherwise it is character wise."
                 (if line 'line type)
                 :expanded t)))
 
-(defun evil-select-inner-object (thing beg end type &optional count line)
+(defun evil-select-inner-restricted-object (thing beg end type &optional count line)
   "Return an inner text object range of COUNT objects.
 Selection is restricted to the current line.
 If COUNT is positive, return objects following point; if COUNT is
@@ -3151,7 +3151,7 @@ linewise, otherwise it is character wise."
   (save-restriction
     (narrow-to-region (save-excursion (beginning-of-line) (point))
                       (save-excursion (end-of-line) (point)))
-    (evil-select-inner-unrestricted-object thing beg end type count line)))
+    (evil-select-inner-object thing beg end type count line)))
 
 (defun evil-select-an-unrestricted-object (thing beg end type count &optional line)
   "Return an outer text object range of COUNT objects.


### PR DESCRIPTION
Before commit

    04b25f6 Add `evil-select-inner-unrestricted-object`

evil-select-inner-object was used for unrestricted selection. 04b25f6
made this function restrict selection to a line, and introduced a new
function evil-select-inner-unrestricted-object that works same way as
evil-select-inner-object before.

But evil-select-inner-object is an API that might be used by people in
custom configuration, and changing behavior of the function would result
in silent breakage.

It is also worth noting that documentation at doc/source/extension.rst
and doc/build/texinfo/evil.texi still mentions the older unrestricted
behavior.

So let's restore the original behavior of evil-select-inner-object by:

1. Renaming evil-select-inner-object → evil-select-inner-restricted-object
2. Renaming evil-select-inner-unrestricted-object → evil-select-inner-object