### PR TITLE
Allow setting selected visual area marks

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2009,6 +2009,10 @@ otherwise, it stays behind."
     (let ((marker (evil-get-marker char t)) alist)
       (unless (markerp marker)
         (cond
+         ((eq marker 'evil-visual-beginning)
+          (setq marker evil-visual-mark))
+         ((eq marker 'evil-visual-goto-end)
+          (setq marker evil-visual-point))
          ((and marker (symbolp marker) (boundp marker))
           (set marker (or (symbol-value marker) (make-marker)))
           (setq marker (symbol-value marker)))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7189,6 +7189,61 @@ echo foxtrot\ngolf hotel"
       "alpha bravo\ncharlie delta
 <alpha bravo\ncharlie delta\n>golf hotel")))
 
+(ert-deftest evil-test-visual-redefine ()
+  "Test redefining a previous selection"
+  :tags '(evil visual)
+  (ert-info ("Redefine characterwise selection")
+    (evil-test-buffer
+      ";; <[T]his> buffer is for notes."
+      ([escape] "gv")
+      ";; <[T]his> buffer is for notes."
+      ([escape] "2lm<2wm>gv")
+      ";; Th<is buffer [i]>s for notes."))
+  (ert-info ("Redefine linewise selection")
+    (evil-test-buffer
+      :visual line
+      "<[a]lpha bravo
+>charlie delta
+echo foxtrot
+golf hotel"
+      ([escape] "gv")
+      "<[a]lpha bravo
+>charlie delta
+echo foxtrot
+golf hotel"
+      ([escape] "2jm>gv")
+      "<alpha bravo
+charlie delta
+[e]cho foxtrot
+>golf hotel"
+      ([escape] "km<gv")
+      "alpha bravo
+<charlie delta
+[e]cho foxtrot
+>golf hotel"))
+  (ert-info ("Redefine blockwise selection")
+    (evil-test-buffer
+      :visual block
+      "<alpha bravo
+charli[e]> delta
+echo foxtrot
+golf hotel"
+      ([escape] "gv")
+      "<alpha bravo
+charli[e]> delta
+echo foxtrot
+golf hotel"
+      ([escape] "2jm>gv")
+      "<alpha bravo
+charlie delta
+echo foxtrot
+golf h[o]>tel"
+      ([escape] "k0m<gv")
+      "alpha bravo
+charlie delta
+<echo foxtrot
+golf h[o]>tel")))
+
 ;;; Replace state
 
 (ert-deftest evil-test-replacement ()


### PR DESCRIPTION
It's useful to set the marks (`<` and `>`) to change what the `gv` command selects.

Fixes #1634

Vim supports it: [:help m<](https://vimhelp.org/motion.txt.html#m%3C)