### PR TITLE
Remove 24.5 from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - 24.5
           - 25.3
           - 26.3
           - 27.1


### PR DESCRIPTION
Debian 9 LTS is now end of life: https://wiki.debian.org/LTS
So I think this is a good indicator we can stop testing against emacs 24.5 (which has been failing for months anyway)