### PR TITLE
Fix daw deleting indentation when deleting the only word in a line

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3207,7 +3207,10 @@ linewise, otherwise it is character wise."
             (setq wsend
                   (evil-with-restriction
                       ;; restrict to current line if we do non-line selection
-                      (and (not line) (line-beginning-position))
+                      (and (not line)
+                           (if (member thing '(evil-word evil-WORD))
+                               (progn (back-to-indentation) (point))
+                             (line-beginning-position)))
                       (and (not line) (line-end-position))
                     (evil-bounds-of-not-thing-at-point thing (- dir))))
             (when wsend (setq other wsend addcurrent t)))))))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -5986,7 +5986,16 @@ Line 2"))
     (evil-test-buffer
       "foo\n  [ ]  bar"
       ("daW")
-      "foo\n[]")))
+      "foo\n[]"))
+  (ert-info ("Deleting the only word on a line doesn't delete indentation")
+    (evil-test-buffer
+     "   [b]ar"
+     ("daw")
+     "  [ ]")
+    (evil-test-buffer
+      "   [b]ar"
+      ("daW")
+      "  [ ]")))
 
 (ert-deftest evil-test-word-objects-cjk ()
   "Test `evil-inner-word' and `evil-a-word' on CJK words"


### PR DESCRIPTION
In vim, deleting an indented word when it's the only word on a line
will just not delete any whitespace.  This applies specifically to
word objects in vim (see
https://github.com/vim/vim/blob/c7bd2f08e531f08723cdc677212a3633d11c9a97/src/textobject.c#L809),
and not any other objects.