### PR TITLE
Clear `evil-this-register` when leaving visual state

### DIFF
--- a/evil-states.el
+++ b/evil-states.el
@@ -420,6 +420,7 @@ If LATER is non-nil, exit after the current command."
           (setq deactivate-mark t)
         (when evil-visual-region-expanded
           (evil-visual-contract-region))
+        (setq evil-this-register nil)
         (evil-change-to-previous-state)))))
 
 (defun evil-visual-tag (&optional selection)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -3058,7 +3058,12 @@ word3[]"))
       ("yiw" "w" "R" "\C-r0")
       "alpha alpha[ ]charlie"
       ([backspace] [backspace] [backspace])
-      "alpha al[a]vo charlie")))
+      "alpha al[a]vo charlie"))
+  (ert-info ("Normal delete after visual delete doesn't clobber register")
+    (evil-test-buffer
+      "[a]lpha bravo charlie delta"
+      ("vf \"xd" "dw" ";\"xp")
+      "charlie alpha delta")))
 
 (ert-deftest evil-test-last-insert-register ()
   "Test last insertion register."


### PR DESCRIPTION
Fixes #1645