### PR TITLE
Save excursion when adding preceeding whitespace to A word

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3210,7 +3210,7 @@ linewise, otherwise it is character wise."
                       ;; restrict to current line if we do non-line selection
                       (and (not line)
                            (if (member thing '(evil-word evil-WORD))
-                               (progn (back-to-indentation) (point))
+                               (save-excursion (back-to-indentation) (point))
                              (line-beginning-position)))
                       (and (not line) (line-end-position))
                     (evil-bounds-of-not-thing-at-point thing (- dir))))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -6000,7 +6000,12 @@ Line 2"))
     (evil-test-buffer
       "   [b]ar"
       ("daW")
-      "  [ ]")))
+      "  [ ]")
+    (ert-info ("But deleting the final word of many behaves as normal")
+      (evil-test-buffer
+        "   foo   [b]ar"
+        ("daw")
+        "   fo[o]"))))
 
 (ert-deftest evil-test-word-objects-cjk ()
   "Test `evil-inner-word' and `evil-a-word' on CJK words"


### PR DESCRIPTION
Fixes #1644