### PR TITLE
Never kill on visual paste when using evil-paste-before

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2131,7 +2131,9 @@ The return value is the yanked text."
   (interactive "*P<x>")
   (setq count (prefix-numeric-value count))
   (if (evil-visual-state-p)
-      (evil-visual-paste count register)
+      ;; This is the only difference with evil-paste-after in visual-state
+      (let ((evil-kill-on-visual-paste nil))
+        (evil-visual-paste count register))
     (evil-with-undo
       (let* ((text (if register
                        (evil-get-register register)

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -451,7 +451,8 @@ before point."
 (defcustom evil-kill-on-visual-paste t
   "Whether pasting in visual state adds the replaced text to the
 kill ring, making it the default for the next paste. The default,
-replicates the default Vim behavior."
+replicates the default Vim behavior for `p'. This is ignored by
+`evil-paste-before' (\\[evil-paste-before]) which never kills on visual paste."
   :type 'boolean
   :group 'evil)
 


### PR DESCRIPTION
This is pretty new in Vim (Jan 2022)