### PR TITLE
Add `evil-goto-last-change` & reverse, taking count arg

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -882,6 +882,18 @@ Columns are counted from zero."
   (evil-goto-mark char noerror)
   (evil-first-non-blank))
 
+(evil-define-motion evil-goto-last-change (count)
+  "Like `goto-last-change' but takes a COUNT rather than a span."
+  (setq this-command 'goto-last-change)
+  (dotimes (_ (or count 1))
+    (goto-last-change nil)))
+
+(evil-define-motion evil-goto-last-change-reverse (count)
+  "Like `goto-last-change-reverse' but takes a COUNT rather than a span."
+  (setq this-command 'goto-last-change-reverse)
+  (dotimes (_ (or count 1))
+    (goto-last-change-reverse nil)))
+
 (evil-define-motion evil-jump-backward (count)
   "Go to older position in jump list.
 To go the other way, press \

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -110,8 +110,8 @@
 (define-key evil-normal-state-map [remap yank-pop] 'evil-paste-pop)
 
 ;; go to last change
-(define-key evil-normal-state-map "g;" 'goto-last-change)
-(define-key evil-normal-state-map "g," 'goto-last-change-reverse)
+(define-key evil-normal-state-map "g;" 'evil-goto-last-change)
+(define-key evil-normal-state-map "g," 'evil-goto-last-change-reverse)
 
 ;; undo
 (define-key evil-normal-state-map "u" 'evil-undo)


### PR DESCRIPTION
Fixes #1639
Preferred to add an evil function and keep goto-chg as it is.