### PR TITLE
Add variable to prevent evil-change from inserting into kill-ring

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1708,7 +1708,8 @@ If TYPE is `line', insertion starts on an empty line.
 If TYPE is `block', the inserted text in inserted at each line
 of the block."
   (interactive "<R><x><y>")
-  (let ((delete-func (or delete-func #'evil-delete))
+  (let ((register (or register (if evil-change-prevent-kill-ring ?_)))
+        (delete-func (or delete-func #'evil-delete))
         (nlines (1+ (evil-count-lines beg end)))
         opoint leftmost-point)
     (save-excursion
@@ -1738,7 +1739,7 @@ of the block."
   (interactive "<R><x><y>")
   (if (and (evil-visual-state-p) (eq 'inclusive type))
       (cl-destructuring-bind (beg* end* &rest) (evil-line-expand beg end)
-          (evil-change-whole-line beg* end* register yank-handler))
+        (evil-change-whole-line beg* end* register yank-handler))
     (evil-change beg end type register yank-handler #'evil-delete-line)))
 
 (evil-define-operator evil-change-whole-line

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1739,7 +1739,7 @@ of the block."
   (interactive "<R><x><y>")
   (if (and (evil-visual-state-p) (eq 'inclusive type))
       (cl-destructuring-bind (beg* end* &rest) (evil-line-expand beg end)
-        (evil-change-whole-line beg* end* register yank-handler))
+          (evil-change-whole-line beg* end* register yank-handler))
     (evil-change beg end type register yank-handler #'evil-delete-line)))
 
 (evil-define-operator evil-change-whole-line

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1424,6 +1424,9 @@ having higher priority.")
 This list exists to apply an inconsistency with vim's change command
 to commands that wrap or redefine it. See emacs-evil/evil#916.")
 
+(defvar evil-change-prevent-kill-ring nil
+  "If non-nil `evil-change' will not add deleted text to `kill-ring'.")
+
 (defvar evil-transient-vars '(cua-mode transient-mark-mode select-active-regions)
   "List of variables pertaining to Transient Mark mode.")
 


### PR DESCRIPTION
This PR adds a variable `evil-change-prevent-kill-ring` that if non-nil causes the text deleted from a call to `evil-change` to be stored in the void register by default.