### PR TITLE
Make sure visual markers are up to date in evil-visual-range

### DIFF
--- a/evil-states.el
+++ b/evil-states.el
@@ -743,6 +743,7 @@ This is a list (BEG END TYPE PROPERTIES...), where BEG is the
 beginning of the selection, END is the end of the selection,
 TYPE is the selection's type, and PROPERTIES is a property list
 of miscellaneous selection attributes."
+  (evil-visual-refresh)
   (apply #'evil-range
          evil-visual-beginning evil-visual-end
          (evil-visual-type)


### PR DESCRIPTION
With composed characters in the buffer, such as with prettify-symbol-mode
active, emacs may adjust point after the post-command-hook is run. In this case,
evils visual markers do not get updated prior to say evil-delete and the deleted
region does not agree with what is seen visually (only part of the composed
characters are deleted). Forcing a last update using evil-visual-refresh
in evil-visual-range resolves this issue.