### PR TITLE
Keep using the old input method in `evil-local-mode`

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -132,6 +132,7 @@
     (when (minibufferp)
       (setq-local evil-default-state 'insert)
       (setq-local evil-echo-state nil))
+    (setq evil-input-method current-input-method)
     ;; The initial state is usually setup by `evil-initialize' when
     ;; the major-mode in a buffer changes. This preliminary
     ;; initialization is only for the case when `evil-local-mode' is


### PR DESCRIPTION
My understanding is that Evil activates `evil-local-mode` as early as possible, but there is no guarantee that it is able to do so before the buffer's input method is set. Unfortunately, the current `evil-local-mode` just discards the buffer's old input method, so the order of these two actions is significant.

As a minimal example, evaluate the following and inspect the resulting buffer:
```elisp
(with-current-buffer (get-buffer-create "no-german-postfix")
  ;;(evil-local-mode)
  (activate-input-method "german-postfix"))
```
No matter the Evil state, the input method is no longer set. In this example, the issue can be worked around by uncommenting the second line, but typically you'd have to modify other people's code. In my case, I noticed it with `rcirc` channel buffers which were missing the input method I set via `rcirc-mode-hook`.

As an easy fix, I propose changing `evil-local-mode` so that it simply starts out with the buffer's old input method for `evil-input-method`.
