### PR TITLE
Handle composed characters in evil-range

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2990,11 +2990,18 @@ If no description is available, return the empty string."
 
 (defun evil-range (beg end &optional type &rest properties)
   "Return a list (BEG END [TYPE] PROPERTIES...).
-BEG and END are buffer positions (numbers or markers),
-TYPE is a type as per `evil-type-p', and PROPERTIES is
-a property list."
+BEG and END are buffer positions (numbers or markers), TYPE is a
+type as per `evil-type-p', and PROPERTIES is a property list. If
+beg or end are inside a sequence of composed characters, adjust
+the positions to be outside of this sequence."
   (let ((beg (evil-normalize-position beg))
         (end (evil-normalize-position end)))
+    (when-let* ((comp (find-composition beg))
+                (valid (nth 2 comp)))
+      (setq beg (nth 0 comp)))
+    (when-let* ((comp (find-composition end))
+                (valid (nth 2 comp)))
+      (setq end (nth 1 comp)))
     (when (and (numberp beg) (numberp end))
       (append (list (min beg end) (max beg end))
               (when (evil-type-p type)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -508,7 +508,11 @@ and the beginning")
         (should (string= (evil-describe 1 2 'exclusive)
                          "1 character"))
         (should (string= (evil-describe 5 2 'exclusive)
-                         "3 characters"))))))
+                         "3 characters")))
+      (compose-region 9 15 "ϐ")         ; visually replaces "buffer" with ϐ
+      (ert-info ("Adjust range to account for composed characters")
+        (should (equal (evil-normalize 10 10 'exclusive)
+                       '(9 15 exclusive)))))))
 
 (ert-deftest evil-test-inclusive-type ()
   "Expand and contract the `inclusive' type"
@@ -533,7 +537,14 @@ and the beginning")
       (should (string= (evil-describe 1 1 'inclusive)
                        "1 character"))
       (should (string= (evil-describe 5 2 'inclusive)
-                       "4 characters")))))
+                       "4 characters")))
+    (compose-region 9 15 "ϐ") ; visually replaces "buffer" with ϐ
+    (ert-info ("Don't end in composed characters")
+      (should (equal (evil-expand 7 12 'inclusive)
+                     '(7 15 inclusive :expanded t))))
+    (ert-info ("Don't begin in composed characters")
+      (should (equal (evil-expand 10 20 'inclusive)
+                     '(9 21 inclusive :expanded t))))))
 
 (ert-deftest evil-test-line-type ()
   "Expand the `line' type"


### PR DESCRIPTION
This is a low-level fix for the composed characters problem (see #1656). The idea is to prevent `evil-range` from returning a range that lands inside a sequence of composed characters. I think this makes sense, because `evil-range` already takes care to return a valid range through calling `evil-normalize-position`, and having the range `(beg end)` start or end inside a sequence of hidden characters, seems like it should be considered invalid.  

If this seems too aggressive, I could see hiding this feature behind a flag. 

Also added some tests. 