### PR TITLE
Compatibility: use $SED instead of sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 SHELL = /bin/sh
 EMACS ?= emacs
+SED ?= sed
 FILES = $(filter-out evil-test-helpers.el evil-tests.el evil-pkg.el,$(wildcard evil*.el))
-VERSION := $(shell sed -ne '/define-package/,$$p' evil-pkg.el | sed -ne '/^\s*"[[:digit:]]\+\(\.[[:digit:]]\+\)*"\s*$$/ s/^.*"\(.*\)".*$$/\1/p')
+VERSION := $(shell $(SED) -ne '/define-package/,$$p' evil-pkg.el | $(SED) -ne '/^\s*"[[:digit:]]\+\(\.[[:digit:]]\+\)*"\s*$$/ s/^.*"\(.*\)".*$$/\1/p')
 ELPAPKG = evil-$(VERSION)
 PROFILER =
 DOC = doc
@@ -20,7 +21,7 @@ compile: $(ELCFILES)
 	@echo Compute dependencies
 	@rm -f .depend
 	@for f in $(FILES); do \
-		sed -n "s/ *(require '\(evil-[^)]*\).*)/$${f}c: \1.elc/p" $$f >> .depend;\
+		$(SED) -n "s/ *(require '\(evil-[^)]*\).*)/$${f}c: \1.elc/p" $$f >> .depend;\
 	done
 
 -include .depend


### PR DESCRIPTION
Hi, I'm using FreeBSD, which has BSD `sed` program, not GNU `sed` . So in my environment `Makefile` doesn't work especially at line 5.

It's great if I could pass actual sed program to use like `SED=gsed make` (especially when installing via package manager like `el-get`) . So I made it variable. 

I think this change doesn't break current behavior.