### PR TITLE
evil-select-parens selects next pair if not in parens

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1477,7 +1477,8 @@ or line COUNT to the top of the window."
      ((memq type '(line screen-line))
       (evil-yank-lines beg end register yank-handler))
      (t
-      (evil-yank-characters beg end register yank-handler)))))
+      (evil-yank-characters beg end register yank-handler)
+      (goto-char beg)))))
 
 (evil-define-operator evil-yank-line (beg end type register)
   "Saves whole lines into the kill-ring."

--- a/evil-common.el
+++ b/evil-common.el
@@ -3465,6 +3465,11 @@ is ignored."
 		      (res (evil-select-paren open close mbeg mbeg
 					      type nil inclusive)))
 		 (if (< (car res) mbeg)
+                     ;; this will error if the beginning of the found parens is before the target paren
+                     ;; this prevents things such as on the line `prova ( verder "((testo)")`,
+                     ;; the inputs `g2ci(` from putting your cursor inside the deleted `()` after `prova`
+                     ;; without this, it would go to the second paren (the unbalanced first paren inside the quotes)
+                     ;; and then do a change there, changing inside the whole paren after `prova`
 		     (error "No surrounding delimiters found")
 		   res)))
            (error "No surrounding delimiters found")))))))

--- a/evil-common.el
+++ b/evil-common.el
@@ -3454,7 +3454,8 @@ is ignored."
                              beg end type count inclusive))))
     (error ; we aren't in the parens, so find next instance
      (save-match-data
-       (goto-char (or (if (and count (> 0 count)) end beg) (point)))
+       (goto-char (or (if (and count (> 0 count)) end beg)
+                      (point)))
        (let ((re (if (characterp open) (string open) open)))
          (if (re-search-forward re nil t count)
              (progn

--- a/evil-common.el
+++ b/evil-common.el
@@ -3457,10 +3457,16 @@ is ignored."
        (goto-char (or (if (and count (> 0 count)) end beg)
                       (point)))
        (let ((re (if (characterp open) (string open) open)))
-         (if (re-search-forward re nil t count)
-             (progn
-               (goto-char (match-beginning 0))
-               (evil-select-paren open close (match-beginning 0) (match-beginning 0) type count inclusive))
+         (if (and (not (string= (string (char-after)) re))
+                  (re-search-forward re nil t count))
+	     (progn
+	       (goto-char (match-beginning 0))
+	       (let* ((mbeg (match-beginning 0))
+		      (res (evil-select-paren open close mbeg mbeg
+					      type nil inclusive)))
+		 (if (< (car res) mbeg)
+		     (error "No surrounding delimiters found")
+		   res)))
            (error "No surrounding delimiters found")))))))
 
 (defun evil-select-quote-thing (thing beg end _type count &optional inclusive)

--- a/evil-common.el
+++ b/evil-common.el
@@ -3459,19 +3459,19 @@ is ignored."
        (let ((re (if (characterp open) (string open) open)))
          (if (and (not (string= (string (char-after)) re))
                   (re-search-forward re nil t count))
-	     (progn
-	       (goto-char (match-beginning 0))
-	       (let* ((mbeg (match-beginning 0))
-		      (res (evil-select-paren open close mbeg mbeg
-					      type nil inclusive)))
-		 (if (< (car res) mbeg)
+             (progn
+               (goto-char (match-beginning 0))
+               (let* ((mbeg (match-beginning 0))
+                      (res (evil-select-paren open close mbeg mbeg
+                                              type nil inclusive)))
+                 (if (< (car res) mbeg)
                      ;; this will error if the beginning of the found parens is before the target paren
                      ;; this prevents things such as on the line `prova ( verder "((testo)")`,
                      ;; the inputs `g2ci(` from putting your cursor inside the deleted `()` after `prova`
                      ;; without this, it would go to the second paren (the unbalanced first paren inside the quotes)
                      ;; and then do a change there, changing inside the whole paren after `prova`
-		     (error "No surrounding delimiters found")
-		   res)))
+                     (error "No surrounding delimiters found")
+                   res)))
            (error "No surrounding delimiters found")))))))
 
 (defun evil-select-quote-thing (thing beg end _type count &optional inclusive)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9494,6 +9494,25 @@ when an error stops the execution of the macro"
      ("@a")
      "inserted text appended tex[t]")))
 
+
+(ert-deftest evil-test-paren-jumping ()
+  :tags '(evil paren)
+  (ert-info ("Test doing motions on parens that you aren't in")
+    (evil-test-buffer
+      "[m]ain(argc, argv) char **argv; {"
+      ("dib" [escape])
+      "main([)] char **argv; {")
+    (evil-test-buffer
+"[#]include \"stdlib.h\"
+main(argc, argv) char **argv; {
+  while (1) malloc(0);
+}"
+      ("ci{  return 0;" [escape])
+"#include \"stdlib.h\"
+main(argc, argv) char **argv; {
+  return 0[;]
+}")))
+
 ;;; Core
 
 (ert-deftest evil-test-initial-state ()

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9507,6 +9507,10 @@ when an error stops the execution of the macro"
       "alpha ([b]ravo) charlie "
       ("$p")
       "alpha (bravo) charlie brav[o]")
+      (evil-test-buffer
+        "[a]lpha (bravo (charlie))"
+        ("2di(")
+        "alpha (bravo ([)]")
     (evil-test-buffer
 "[#]include \"stdlib.h\"
 main(argc, argv) char **argv; {

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9494,7 +9494,6 @@ when an error stops the execution of the macro"
      ("@a")
      "inserted text appended tex[t]")))
 
-
 (ert-deftest evil-test-paren-jumping ()
   :tags '(evil paren)
   (ert-info ("Test doing motions on parens that you aren't in")
@@ -9502,6 +9501,12 @@ when an error stops the execution of the macro"
       "[m]ain(argc, argv) char **argv; {"
       ("dib" [escape])
       "main([)] char **argv; {")
+    (evil-test-buffer
+      "[a]lpha (bravo) charlie "
+      ("yi(")
+      "alpha ([b]ravo) charlie "
+      ("$p")
+      "alpha (bravo) charlie brav[o]")
     (evil-test-buffer
 "[#]include \"stdlib.h\"
 main(argc, argv) char **argv; {


### PR DESCRIPTION
In modern versions of Vim (and Neovim), doing an action on something in parens will jump to the next instance of those parens and perform the action on them if you're not in those parens.

For example, if you are on the line `int main(int argc, char **argv) {` and type `0cib`, it will change everything inside the parens even though you initially went to the beginning of the line. This pull request adds this functionality.

This feature already works on strings.

One bug is that if you yank something in parens and it needs to jump to the next pair because you're not in parens, in Vim it moves your cursor to the beginning of the next pair, while here it doesn't move your cursor. I couldn't figure out how to fix this.