### PR TITLE
Fix pasting from ?+ register in Emacs 29

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -2148,7 +2148,7 @@ The following special registers are supported.
                      (current-kill reg t))))
              ((memq register '(?* ?+))
               (let ((what (if (eq register ?*) 'PRIMARY 'CLIPBOARD)))
-                (if (version<= "25" emacs-version)
+                (if (version<= "29" emacs-version)
                     (gui--selection-value-internal what)
                   ;; the following code is modified from `x-selection-value-internal'
                   (let ((request-type (or (and (boundp 'x-select-request-type)

--- a/evil-common.el
+++ b/evil-common.el
@@ -2150,7 +2150,10 @@ The following special registers are supported.
               (let ((what (if (eq register ?*) 'PRIMARY 'CLIPBOARD)))
                 (if (version<= "29" emacs-version)
                     (gui--selection-value-internal what)
-                  ;; the following code is modified from `x-selection-value-internal'
+                  ;; The following code is based on `x-selection-value-internal'
+                  ;; (now `gui--selection-value-internal') circa Emacs 24. We're
+                  ;; unsure why exactly it's duplicated here, and it's possible
+                  ;; it needn't be for newer versions of Emacs.
                   (let ((request-type (or (and (boundp 'x-select-request-type)
                                                x-select-request-type)
                                           '(UTF8_STRING COMPOUND_TEXT STRING)))

--- a/evil-common.el
+++ b/evil-common.el
@@ -2147,22 +2147,23 @@ The following special registers are supported.
                 (and (< reg (length kill-ring))
                      (current-kill reg t))))
              ((memq register '(?* ?+))
-              ;; the following code is modified from
-              ;; `x-selection-value-internal'
-              (let ((what (if (eq register ?*) 'PRIMARY 'CLIPBOARD))
-                    (request-type (or (and (boundp 'x-select-request-type)
-                                           x-select-request-type)
-                                      '(UTF8_STRING COMPOUND_TEXT STRING)))
-                    text)
-                (unless (consp request-type)
-                  (setq request-type (list request-type)))
-                (while (and request-type (not text))
-                  (condition-case nil
-                      (setq text (evil-get-selection what (pop request-type)))
-                    (error nil)))
-                (when text
-                  (remove-text-properties 0 (length text) '(foreign-selection nil) text))
-                text))
+              (let ((what (if (eq register ?*) 'PRIMARY 'CLIPBOARD)))
+                (if (version<= "25" emacs-version)
+                    (gui--selection-value-internal what)
+                  ;; the following code is modified from `x-selection-value-internal'
+                  (let ((request-type (or (and (boundp 'x-select-request-type)
+                                               x-select-request-type)
+                                          '(UTF8_STRING COMPOUND_TEXT STRING)))
+                        text)
+                    (unless (consp request-type)
+                      (setq request-type (list request-type)))
+                    (while (and request-type (not text))
+                      (condition-case nil
+                          (setq text (evil-get-selection what (pop request-type)))
+                        (error nil)))
+                    (when text
+                      (remove-text-properties 0 (length text) '(foreign-selection nil) text))
+                    text))))
              ((eq register ?\C-W)
               (unless (evil-ex-p)
                 (user-error "Register <C-w> only available in ex state"))


### PR DESCRIPTION
I found that on Emacs v29, `" + p` does not paste from the system clipboard if the clipboard was populated outside emacs, rather it pastes from the kill ring.

It looks like this same bug briefly existed in the built-in `gui-selection-value` until it was fixed in [this commit](https://github.com/emacs-mirror/emacs/commit/2289fafeaf) by checking a new var `gui--last-cut-in-clipboard`.

It also looks like `gui--selection-value-internal` (previously `x-selection-value-internal`) has drifted from the evil code that's based on it.  Rather than attempt to bring the evil code up to date while keeping compatibility with Emacs 24, I opted for a version check so we can just call `gui--selection-value-internal` if it exists.

It's unclear to me why this code was duplicated in evil in the first place. It's entirely possible it was for a good and still-applicable reason, in which case merging my fix here would be problematic. Anyway, [here's the commit where it happened](https://github.com/eeshugerman/evil/commit/3841842) -- @f-fr, do you happen to recall?