### PR TITLE
Fix logical/visual line move followed by the other

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1404,8 +1404,8 @@ If STATE is given it used a parsing state at point."
 Signals an error at buffer boundaries unless NOERROR is non-nil."
   (setq this-command (if (< count 0) #'previous-line #'next-line))
   (let ((last-command
+         ;; Reset tmp goal column between visual/logical movement
          (when (eq line-move-visual (consp temporary-goal-column))
-           ;; Reset tmp goal column between visual/logical movement
            last-command))
         (opoint (point)))
     (evil-signal-without-movement

--- a/evil-common.el
+++ b/evil-common.el
@@ -1405,7 +1405,8 @@ Signals an error at buffer boundaries unless NOERROR is non-nil."
   (setq this-command (if (< count 0) #'previous-line #'next-line))
   (let ((last-command
          ;; Reset tmp goal column between visual/logical movement
-         (when (eq line-move-visual (consp temporary-goal-column))
+         (when (or (eq line-move-visual (consp temporary-goal-column))
+                   (eq temporary-goal-column most-positive-fixnum))
            last-command))
         (opoint (point)))
     (evil-signal-without-movement

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -3340,6 +3340,19 @@ Below some empty line"
       ("jjjkk")
       "abc\nab[c]def\n\nabcd\n")))
 
+(ert-deftest evil-test-logical-visual-next-line ()
+  "Test alternating between logical and visual next/previous line motions."
+  :tags '(evil motion)
+  (skip-unless (and (not noninteractive) (> (window-width) 1)))
+  (evil-test-buffer
+   "[]\nyy\n"
+   (insert (make-string (window-width) ?x)) ; Make first line soft-wrap
+   (goto-char (point-min))
+   ("gjj")
+   (should (= (current-column) 1))
+   ("Gkgk")
+   (should (evil-eolp))))
+
 (ert-deftest evil-test-other-commands-preserve-column ()
   "Test other comamnds preserve the column, when appropriate."
   :tags '(evil motion)


### PR DESCRIPTION
This pull request does not have the issue that #1470 had: The workaround is only applied at the boundaries of logical and visual line movements, which were the only places where things went awry.

I removed support for `next-line-add-newlines`, almost feel like it would be better to add that code to the `evil-next-line` and `evil-next-visual-line` functions. In any case, it feels wrong to have `evil-line-move` call `next-line`/`previous-line`.

No tests yet, maybe someone could help out with that?

Resolves #1469