### PR TITLE
Fixup evil-select-paren #1673 for multichars delimiters

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3457,7 +3457,7 @@ is ignored."
        (goto-char (or (if (and count (> 0 count)) end beg)
                       (point)))
        (let ((re (if (characterp open) (string open) open)))
-         (if (and (not (string= (string (char-after)) re))
+         (if (and (not (looking-at-p re))
                   (re-search-forward re nil t count))
              (progn
                (goto-char (match-beginning 0))


### PR DESCRIPTION
Hi,
I noticed after the merge of #1673 that I didn't take into account the case in which the open parens are a string. In that
case the condition always gives false and it keeps looping, because I compared only with the first char. Also didn't account for the case in which we are at the `eob`, where `char-after` gives `nil`, resulting in an unfriendly error message.
In this fixup `char-after` is replaced by `looking-at-p`, leveraging the same regexp string used afterwards.  I thought to 
add a `regexp-quote` call to that, in case the open delimiter has special chars, but noticed that in case of string 
delimiters, they are already assumed to be correct regexps by the inner function `evil-up-block`.
E.g. before the fix:
`|prova <~`
`(evil-select-paren "<~" "~>" (point) (point) 'inclusive nil 'inclusive)`
keeps looping until exceeds the resources' utilization

`prova |`
`(evil-select-paren "<~" "~>" (point) (point) 'inclusive nil 'inclusive)`
gives `(wrong-type-argument characterp nil)`

After the fix they regularly show the error message.