### PR TITLE
Fix evil-select-paren #1673 for regexp special chars

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3456,7 +3456,7 @@ is ignored."
      (save-match-data
        (goto-char (or (if (and count (> 0 count)) end beg)
                       (point)))
-       (let ((re (if (characterp open) (string open) open)))
+       (let ((re (if (characterp open) (regexp-quote (string open)) open)))
          (if (and (not (looking-at-p re))
                   (re-search-forward re nil t count))
              (progn

--- a/evil-common.el
+++ b/evil-common.el
@@ -3457,7 +3457,7 @@ is ignored."
        (goto-char (or (if (and count (> 0 count)) end beg)
                       (point)))
        (let ((re (if (characterp open) (string open) open)))
-         (if (and (not (string= (string (char-after)) re))
+         (if (and (not (looking-at-p re))
                   (re-search-forward re nil t count))
              (progn
                (goto-char (match-beginning 0))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9532,10 +9532,16 @@ when an error stops the execution of the macro"
       "alpha ([b]ravo) charlie "
       ("$p")
       "alpha (bravo) charlie brav[o]")
-      (evil-test-buffer
-        "[a]lpha (bravo (charlie))"
-        ("2di(")
-        "alpha (bravo ([)]")
+    (evil-test-buffer
+     "[a]lpha (bravo (charlie))"
+     ("2di(")
+     "alpha (bravo ([)]")
+    (evil-test-buffer
+      :point-start "("
+      :point-end ")"
+     "(a)lpha [bravo [charlie]] [bravo]"
+     ("3di[")
+     "alpha [bravo [charlie]] [(])")
     (evil-test-buffer
 "[#]include \"stdlib.h\"
 main(argc, argv) char **argv; {


### PR DESCRIPTION
Hi,
sorry for the scattered PRs, but i figured out a bug on a very common use case, that is jumping to next bracket.
When the open delimiter is a single character which has special behavior in regexps, the call `(string open)` gives the
char not escaped, and the following functions that use such regexp fail.
It causes the common case of commands on `evil-a/inner-bracket` textobjects to fail, for instance:
`|prova di [testo]`
`ci[`
gives evil-motion-range: Invalid regexp: "Unmatched [ or [^"
Now that should be fine, thanks for your consideration.