### PR TITLE
Revert "Make sure visual markers are up to date in evil-visual-range"

### DIFF
--- a/evil-states.el
+++ b/evil-states.el
@@ -754,7 +754,6 @@ This is a list (BEG END TYPE PROPERTIES...), where BEG is the
 beginning of the selection, END is the end of the selection,
 TYPE is the selection's type, and PROPERTIES is a property list
 of miscellaneous selection attributes."
-  (evil-visual-refresh)
   (apply #'evil-range
          evil-visual-beginning evil-visual-end
          (evil-visual-type)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -5894,6 +5894,19 @@ Line 2"))
      (error user-error "`i")
      "One line is enough if we use backtick to [n]avigate")))
 
+(ert-deftest evil-automatic-marks-test ()
+  "Test that certain commands automatically set mark(er)s"
+  :tags '(evil)
+  (ert-info ("Visual selection sets angle-bracket marks")
+    (evil-test-buffer
+      "alpha br[a]vo charlie"
+      ("viw" [escape] "$")
+      "alpha bravo charli[e]"
+      ("`>")
+      "alpha brav[o] charlie"
+      ("`<")
+      "alpha [b]ravo charlie")))
+
 (ert-deftest evil-test-flyspell-motions ()
   "Test flyspell motions"
   :tags '(evil motion)


### PR DESCRIPTION
This reverts commit 7133220.

@justbur see my message in https://github.com/emacs-evil/evil/pull/1655 - I'm reverting this, but please feel free to make a PR to re-add the functionality you want without breaking the new test.