### PR TITLE
Select the correct window after rotating windows with evil-window-rot…

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4661,7 +4661,7 @@ If ARG is empty, maximize the current window height."
         (window-state-put (car slist) (car wlist))
         (setq wlist (cdr wlist)
               slist (cdr slist)))
-      (select-window (car (last (window-list)))))))
+      (select-window (cadr (last (window-list)))))))
 
 (evil-define-command evil-window-rotate-downwards ()
   "Rotate the windows according to the current cyclic ordering."
@@ -4674,7 +4674,7 @@ If ARG is empty, maximize the current window height."
         (window-state-put (car slist) (car wlist))
         (setq wlist (cdr wlist)
               slist (cdr slist)))
-      (select-window (cadr (window-list))))))
+      (select-window (car (window-list))))))
 
 (evil-define-command evil-window-exchange (count)
   "Without COUNT: exchange current window with next one.


### PR DESCRIPTION
…ate-*

I've just discovered evil-window-rotate-downwards and evil-window-rotate-upwards have a really obvious bug. 

They rotate the windows, but instead of keeping the cursor in the same window it was in before, it selects the previous window.

So say you have these windows:
```
[a: ][c: x]
[b: ]
```
and `c` has the cursor, indicated by the x

you want to rotate them clockwise via `C-w r`

what it should do is this:
```
[b: ][a: ]
[c: x]
```

but what it does is this:
```
[b: x][a: ]
[c: ]
```
It's rotating the selected cursor the wrong way.

and it's vice versa for counter-clockwise rotation via `C-w R`.

The fix is really simple and works for me.