### PR TITLE
Simplify temporary-goal-column logic

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2061,8 +2061,7 @@ See also `evil-shift-left'."
       (move-to-column (max 0 (+ col-for-insert first-shift))))
      (evil-start-of-line (evil-first-non-blank))
      ((evil--stick-to-eol-p) (move-end-of-line 1))
-     (t (move-to-column (or goal-column evil-operator-start-col col-for-insert))))
-    (setq temporary-goal-column 0)))
+     (t (move-to-column (or goal-column evil-operator-start-col col-for-insert))))))
 
 (defun evil-delete-indentation ()
   "Delete all indentation on current line."
@@ -2689,8 +2688,7 @@ the lines."
        ((or (eq (evil-visual-type) 'line)
             (and (eq (evil-visual-type) 'block)
                  (memq last-command '(next-line previous-line))
-                 (numberp temporary-goal-column)
-                 (= temporary-goal-column most-positive-fixnum)))
+                 (eq temporary-goal-column most-positive-fixnum)))
         (evil-visual-rotate 'upper-left)
         (evil-append-line count vcount))
        ((eq (evil-visual-type) 'block)

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -492,12 +492,11 @@ and jump to the corresponding one."
    (count
     (evil-ensure-column
       (goto-char
-       (evil-normalize-position
-        (let ((size (- (point-max) (point-min))))
-          (+ (point-min)
-             (if (> size 80000)
-                 (* count (/ size 100))
-               (/ (* count size) 100)))))))
+       (let ((size (- (point-max) (point-min))))
+         (+ (point-min)
+            (if (> size 80000)
+                (* count (/ size 100))
+              (/ (* count size) 100))))))
     (setq evil-this-type 'line))
    ((and (evil-looking-at-start-comment t)
          (let ((pnt (point)))
@@ -4252,9 +4251,7 @@ range. The given argument is passed straight to
 Default position is the beginning of the buffer."
   :jump t
   (interactive "<N>")
-  (let ((position (evil-normalize-position
-                   (or position (point-min)))))
-    (goto-char position)))
+  (goto-char (or position (point-min))))
 
 (evil-define-operator evil-ex-line-number (beg end)
   "Print the last line number."

--- a/evil-common.el
+++ b/evil-common.el
@@ -2464,33 +2464,24 @@ take at least two arguments, the beginning and end of each
 line.  If PASS-COLUMNS is non-nil, these values are the columns,
 otherwise they are buffer positions.  Extra arguments to FUNC may
 be passed via ARGS."
-  (let ((eol-col (and (memq last-command '(next-line previous-line))
-                      (numberp temporary-goal-column)
-                      temporary-goal-column))
-        startcol startpt endcol endpt)
+  (let (startcol startpt endcol endpt)
     (save-excursion
       (goto-char beg)
-      (setq startcol (current-column))
-      (beginning-of-line)
-      (setq startpt (point))
+      (setq startcol (current-column)
+            startpt (line-beginning-position))
       (goto-char end)
       (setq endcol (current-column))
       (forward-line 1)
       (setq endpt (point-marker))
       ;; ensure the start column is the left one.
       (evil-sort startcol endcol)
-      ;; maybe find maximal column
-      (when eol-col
-        (setq eol-col 0)
+      ;; maybe extend up to EOL
+      (when (and (memq last-command '(next-line previous-line))
+                 (eq temporary-goal-column most-positive-fixnum))
         (goto-char startpt)
         (while (< (point) endpt)
-          (setq eol-col (max eol-col
-                             (evil-column (line-end-position))))
-          (forward-line 1))
-        (setq endcol (max endcol
-                          (min eol-col
-                               (1+ (min (1- most-positive-fixnum)
-                                        (truncate temporary-goal-column)))))))
+          (setq endcol (max endcol (evil-column (line-end-position))))
+          (forward-line 1)))
       ;; start looping over lines
       (goto-char startpt)
       (while (< (point) endpt)

--- a/evil-common.el
+++ b/evil-common.el
@@ -1014,9 +1014,7 @@ so it is more compatible with Evil's notions of eol & tracking."
   "Restrict the buffer to BEG and END.
 BEG or END may be nil, specifying a one-sided restriction including
 `point-min' or `point-max'. See also `evil-with-restriction.'"
-  (setq beg (or (evil-normalize-position beg) (point-min)))
-  (setq end (or (evil-normalize-position end) (point-max)))
-  (narrow-to-region beg end))
+  (narrow-to-region (or beg (point-min)) (or end (point-max))))
 
 (defmacro evil-with-restriction (beg end &rest body)
   "Execute BODY with the buffer narrowed to BEG and END.
@@ -2315,8 +2313,6 @@ variable `evil-kbd-macro-suppress-motion-error'."
 (defun evil-move-mark (pos)
   "Set buffer's mark to POS.
 If POS is nil, delete the mark."
-  (when pos
-    (setq pos (evil-normalize-position pos)))
   (set-marker (mark-marker) pos))
 
 (defun evil-save-transient-mark-mode ()

--- a/evil-macros.el
+++ b/evil-macros.el
@@ -707,9 +707,7 @@ be transformations on buffer positions, like `:expand' and `:contract'.
            `(defun ,name (beg end &rest properties)
               ,(format "Return size of %s from BEG to END \
 with PROPERTIES.\n\n%s%s" type string doc)
-              (let ((beg (evil-normalize-position beg))
-                    (end (evil-normalize-position end))
-                    (type ',type)
+              (let ((type ',type)
                     plist range)
                 (when (and beg end)
                   (save-excursion
@@ -731,9 +729,7 @@ with PROPERTIES.\n\n%s%s" type string doc)
            `(defun ,name (beg end &rest properties)
               ,(format "Perform %s transformation on %s from BEG to END \
 with PROPERTIES.\n\n%s%s" sym type string doc)
-              (let ((beg (evil-normalize-position beg))
-                    (end (evil-normalize-position end))
-                    (type ',type)
+              (let ((type ',type)
                     plist range)
                 (when (and beg end)
                   (save-excursion

--- a/evil-states.el
+++ b/evil-states.el
@@ -281,7 +281,7 @@ the selection is enabled.
   ;; refresh the :corner property
   (setq evil-visual-properties
         (plist-put evil-visual-properties :corner
-                   (evil-visual-block-corner 'upper-left))))
+                   (evil-visual-block-corner))))
 
 (evil-define-state visual
   "Visual state."
@@ -812,37 +812,21 @@ the horizontal or vertical component of CORNER is used.
 CORNER defaults to `upper-left'."
   (let* ((point (or point (point)))
          (mark (or mark (mark t)))
-         (corner (symbol-name
-                  (or corner
-                      (and (overlayp evil-visual-overlay)
-                           (overlay-get evil-visual-overlay
-                                        :corner))
-                      'upper-left)))
+         (corner (or corner
+                     (when (overlayp evil-visual-overlay)
+                       (overlay-get evil-visual-overlay :corner))
+                     'upper-left))
          (point-col (evil-column point))
          (mark-col (evil-column mark))
-         horizontal vertical)
-    (cond
-     ((= point-col mark-col)
-      (setq horizontal
-            (or (and (string-match "left\\|right" corner)
-                     (match-string 0 corner))
-                "left")))
-     ((< point-col mark-col)
-      (setq horizontal "left"))
-     ((> point-col mark-col)
-      (setq horizontal "right")))
-    (cond
-     ((= (line-number-at-pos point)
-         (line-number-at-pos mark))
-      (setq vertical
-            (or (and (string-match "upper\\|lower" corner)
-                     (match-string 0 corner))
-                "upper")))
-     ((< point mark)
-      (setq vertical "upper"))
-     ((> point mark)
-      (setq vertical "lower")))
-    (intern (format "%s-%s" vertical horizontal))))
+         (upperp (if (= (line-number-at-pos point) (line-number-at-pos mark))
+                     (memq corner '(upper-left upper-right))
+                   (< point mark)))
+         (leftp (if (= point-col mark-col)
+                    (memq corner '(upper-left lower-left))
+                  (< point-col mark-col))))
+    (if upperp
+        (if leftp 'upper-left 'upper-right)
+      (if leftp 'lower-left 'lower-right))))
 
 ;;; Operator-Pending state
 

--- a/evil-states.el
+++ b/evil-states.el
@@ -500,14 +500,12 @@ mark and point, use `evil-visual-select' instead."
 If TYPE is given, also set the Visual type.
 If MESSAGE is given, display it in the echo area."
   (interactive)
-  (let* ((point (evil-normalize-position
-                 (or point (point))))
-         (mark (evil-normalize-position
-                (or mark
-                    (when (or (evil-visual-state-p)
-                              (region-active-p))
-                      (mark t))
-                    point))))
+  (let* ((point (or point (point)))
+         (mark (or mark
+                   (when (or (evil-visual-state-p)
+                             (region-active-p))
+                     (mark t))
+                   point)))
     (unless (evil-visual-state-p)
       (evil-visual-state))
     (evil-active-region 1)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -1630,7 +1630,12 @@ New Tex[t]
     :state visual
     "<    Line with too much indentation.>"
     ("=")
-    "Line with too much indentation."))
+    "Line with too much indentation.")
+  (ert-info ("Can repeat evil-indent without errors")
+    (evil-test-buffer
+     "[ ]x\n x"
+     ("==j.")
+     "x\nx")))
 
 (ert-deftest evil-test-keypress-parser ()
   "Test `evil-keypress-parser'"

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7274,7 +7274,14 @@ Tiny ln"
      "Short 
 A much
 A me[d]
-Tiny ")))
+Tiny "))
+  (ert-info ("Visual block does not extend up to curswant unless tracking EOL")
+    (evil-test-buffer
+     "[a]bc
+"
+     ("\C-vfcjd")
+     "[b]c
+")))
 
 (ert-deftest evil-test-visual-restore ()
   "Test restoring a previous selection"

--- a/evil-types.el
+++ b/evil-types.el
@@ -104,10 +104,8 @@ and will be removed in a future version."
   :contract (lambda (beg end)
               (evil-range beg (max beg (1- end))))
   :normalize (lambda (beg end)
-               (goto-char end)
-               (when (eq (char-after) ?\n)
-                 (setq end (max beg (1- end))))
-               (evil-range beg end))
+               (evil-range beg (if (eq (char-after end) ?\n)
+                                   (max beg (1- end)) end)))
   :string (lambda (beg end)
             (let ((width (- end beg)))
               (format "%s character%s" width


### PR DESCRIPTION
In `evil-ensure-column` there is no point in normalizing `temporary-goal-column` a second time after BODY, since that variable is used to store the saved column that must not be overwritten. Also tracking EOL after `evil-end-of-line` is already handled as it fakes being a `next-line` command.

In `evil-apply-on-block` only the case of `temporary-goal-column` equaling `most-positive-fixnum` is relevant, as other column values would be contained inside BEG..END.

Adds a test for commit 7aa71576d258b9546238f6dbd4cf5ca0a1b70088.