### PR TITLE
evil-core: fix dead loop that match data was changed in the advice function of  set-window-buffer

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -372,7 +372,7 @@ then this function does nothing."
     (when (get-buffer (ad-get-arg 1))
       (with-current-buffer (ad-get-arg 1)
         (unless evil-local-mode
-          (evil-local-mode 1))))))
+          (save-match-data (evil-local-mode 1)))))))
 
 ;; Refresh cursor color.
 ;; Cursor color can only be set for each frame but not for each buffer.


### PR DESCRIPTION
Hi,

When `evil` mode enable, the statement `(org-table-clean-line "|a|")` will run into dead loop.
https://lists.gnu.org/archive/html/emacs-orgmode/2022-12/msg00000.html

The root cause is the match data is changed by the advice function of `set-window-buffer` from evil.

The call chain is `(org-table-clean-line)` --> `(org-string-width)` --> `(set-window-buffer)`, and the in advice function of `set-window-buffer` will call the `eval-local-mode`, in which the match data is changed. 

This patch will fix the dead loop for the evil package should not affect the orgmode.

Please help review and apply the patch. Thanks