### PR TITLE
Skip overlays-in in evil-next-flyspell-error

### DIFF
--- a/evil-tests.el
+++ b/evil-tests.el
@@ -68,6 +68,7 @@
 (require 'ert)
 (require 'evil)
 (require 'evil-test-helpers)
+(require 'ispell)
 
 ;;; Code:
 
@@ -5915,7 +5916,7 @@ Line 2"))
 (ert-deftest evil-test-flyspell-motions ()
   "Test flyspell motions"
   :tags '(evil motion)
-  (skip-unless (executable-find "aspell"))
+  (skip-unless (condition-case _ (progn (ispell-check-version) t) (error)))
   (ert-info ("Simple")
     (evil-test-buffer
       "[I] cannt tpye for lyfe"
@@ -5968,8 +5969,7 @@ Line 2"))
         "I cannt [t]pye for lyfe"
         ("]s")
         "I cannt tpye for [l]yfe"
-        ("]s")
-        "I cannt tpye for [l]yfe")))
+        (error search-failed "]s"))))
   (ert-info ("One mistake")
     (evil-test-buffer
       "[I]'m almst there..."
@@ -5984,10 +5984,8 @@ Line 2"))
       "[I]'ve learned to type!"
       (flyspell-mode)
       (flyspell-buffer)
-      ("]s")
-      "[I]'ve learned to type!"
-      ("[s")
-      "[I]'ve learned to type!")))
+      (error search-failed "]s")
+      (error search-failed "[s"))))
 
 ;;; Text objects
 


### PR DESCRIPTION
Searching through the results of `overlays-in`, in addition to looping with `next-overlay-change`/`overlays-at`, is essentially doing the same work twice. This commit opts for only doing the latter.

In addition, some other fixes are

* Avoid requiring flyspell.
* Fail immediately if no spelling error was found regardless of count, and signal error in that case so that macros are aborted like in Vim.
* Echo a notice when search wrapped around.
* Make `[s` and `s]` push the previous position onto the jump list.
* Run tests when suitable spell checker other than aspell is available.