### PR TITLE
Stop the '[/'< and ']/'> marks from intertwining

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2407,10 +2407,8 @@ leave the cursor just after the new text."
       (when evil-kill-on-visual-paste
         (current-kill -1))
       ;; Ensure that gv can restore visually pasted area...
-      (setq evil-visual-previous-mark evil-visual-mark
-            evil-visual-mark (evil-get-marker (if (< 0 dir) ?\[ ?\]) t)
-            evil-visual-previous-point evil-visual-point
-            evil-visual-point (evil-get-marker (if (< 0 dir) ?\] ?\[) t))
+      (set-marker evil-visual-point (evil-get-marker (if (< dir 0) ?\[ ?\]) t))
+      (set-marker evil-visual-mark (evil-get-marker (if (< dir 0) ?\] ?\[) t))
       ;; mark the last paste as visual-paste
       (setq evil-last-paste
             (list (nth 0 evil-last-paste)

--- a/evil-common.el
+++ b/evil-common.el
@@ -2160,21 +2160,6 @@ The earlier settings of Transient Mark mode are stored in
             (funcall var (if val 1 -1))
           (setq var val))))))
 
-(defun evil-save-mark ()
-  "Save the current mark, including whether it is transient.
-See also `evil-restore-mark'."
-  (unless evil-visual-previous-mark
-    (setq evil-visual-previous-mark (mark t))
-    (evil-save-transient-mark-mode)))
-
-(defun evil-restore-mark ()
-  "Restore the mark, including whether it was transient.
-See also `evil-save-mark'."
-  (when evil-visual-previous-mark
-    (evil-restore-transient-mark-mode)
-    (evil-move-mark evil-visual-previous-mark)
-    (setq evil-visual-previous-mark nil)))
-
 ;; In theory, an active region implies Transient Mark mode, and
 ;; disabling Transient Mark mode implies deactivating the region.
 ;; In practice, Emacs never clears `mark-active' except in Transient
@@ -2534,9 +2519,6 @@ is negative this is a more recent kill."
   (unless evil-last-paste
     (user-error "Previous paste command used a register"))
   (evil-undo-pop)
-  (when (eq last-command 'evil-visual-paste)
-    (evil-swap evil-visual-previous-mark evil-visual-mark)
-    (evil-swap evil-visual-previous-point evil-visual-point))
   (goto-char (nth 2 evil-last-paste))
   (setq this-command (nth 0 evil-last-paste))
   ;; use temporary kill-ring, so the paste cannot modify it

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7436,6 +7436,12 @@ charlie delta
 <echo foxtrot
 golf h[o]>tel")))
 
+(ert-deftest evil-test-visual-separate-from-operator-marks ()
+  "Test that visual selection is kept separate from the '[ and '] marks (#1744)."
+  (evil-test-buffer "x\ny"
+    ("ylvpjxgv")
+    "[x]\n"))
+
 ;;; Replace state
 
 (ert-deftest evil-test-replacement ()

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1733,14 +1733,8 @@ instead of `buffer-undo-list'.")
 (evil-define-local-var evil-visual-point nil
   "The position of point in Visual state, a marker.")
 
-(evil-define-local-var evil-visual-previous-point nil
-  "The position of point before Visual state, a marker.")
-
 (evil-define-local-var evil-visual-mark nil
   "The position of mark in Visual state, a marker.")
-
-(evil-define-local-var evil-visual-previous-mark nil
-  "The position of mark before Visual state, a marker.")
 
 (evil-define-local-var evil-visual-selection nil
   "The kind of Visual selection.


### PR DESCRIPTION
The function evil-visual-paste would assign to evil-visual-point/-mark the same markers used by the '[ and '] marks. Therefore after a single visual paste, Normal mode "gv" in that buffer would act funkily ever after. This commit fixes that.

Also removes unused definitions related to evil-visual-previous-point/-mark.

To reproduce:
* Enter new buffer with content:
  ```
  x
  y
  ```
* With cursor on `y`, type `ylvpkxgv`.

The expectation is that `y` should be re-selected. Instead the empty upper line is selected due to it being the previously changed text.