### PR TITLE
Use scroll-preserve-screen-position for C-u/C-d

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1141,17 +1141,6 @@ the loop immediately quits. See also `evil-loop'.
              (when (= (point) ,orig)
                (throw ',done ,i))))))))
 
-(defmacro evil-signal-without-movement (&rest body)
-  "Catch errors provided point moves within this scope."
-  (declare (indent defun)
-           (debug t))
-  `(let ((p (point)))
-     (condition-case err
-         (progn ,@body)
-       (error
-        (when (= p (point))
-          (signal (car err) (cdr err)))))))
-
 (defun evil-signal-at-bob-or-eob (&optional count)
   "Signal error if `point' is at boundaries.
 If `point' is at bob and COUNT is negative this function signal

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -3256,12 +3256,12 @@ sed do eiusmod tempor incididunt"))
   (ert-info ("End of line")
     (evil-test-buffer
       ";; This buffer is for notes[.]"
-      (should-error (execute-kbd-macro "l"))
-      (should-error (execute-kbd-macro "10l"))))
+      (error end-of-line "l")
+      (error end-of-line "10l")))
   (ert-info ("Until end-of-line")
     (evil-test-buffer
       "[;]; This buffer is for notes."
-      ("100l")
+      (error end-of-line "100l")
       ";; This buffer is for notes[.]"))
   (ert-info ("On empty line")
     (evil-test-buffer
@@ -3292,7 +3292,7 @@ Below some empty line"
   (ert-info ("Until beginning-of-line")
     (evil-test-buffer
       ";; This[ ]buffer is for notes."
-      ("100h")
+      (error beginning-of-line "100h")
       "[;]; This buffer is for notes."))
   (ert-info ("On empty line")
     (evil-test-buffer

--- a/evil-types.el
+++ b/evil-types.el
@@ -118,18 +118,14 @@ and will be removed in a future version."
             (evil-range
              (progn
                (goto-char beg)
-               (min (line-beginning-position)
-                    (progn
-                      ;; move to beginning of line as displayed
-                      (evil-move-beginning-of-line)
-                      (line-beginning-position))))
+               ;; move to beginning of line as displayed
+               (evil-move-beginning-of-line)
+               (point))
              (progn
                (goto-char end)
-               (max (line-beginning-position 2)
-                    (progn
-                      ;; move to end of line as displayed
-                      (evil-move-end-of-line)
-                      (line-beginning-position 2))))))
+               ;; move to the end of line as displayed
+               (evil-move-end-of-line)
+               (line-beginning-position 2))))
   :contract (lambda (beg end)
               (evil-range beg (max beg (1- end))))
   :string (lambda (beg end)


### PR DESCRIPTION
Instead of manually maintaining the cursor screen position with

```elisp
(let ((xy (evil-posn-x-y (posn-at-point))))
  ...
  (goto-char (posn-point (posn-at-x-y (car xy) (cdr xy)))))
```

when scrolling via CTRL-U and CTRL-D, using the C functions `scroll-up`/`scroll-down` with `scroll-preserve-screen-position` set has the potential of being more performant.