### PR TITLE
Fix Fundamental mode hack

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -410,7 +410,7 @@ See also `evil-get-command-property'."
 To set multiple properties at once, see
 `evil-set-command-properties' and `evil-add-command-properties'."
   (evil-put-property 'evil-command-properties command property value))
-(defalias 'evil-put-command-property 'evil-set-command-property)
+(defalias 'evil-put-command-property #'evil-set-command-property)
 
 (defun evil-add-command-properties (command &rest properties)
   "Add PROPERTIES to COMMAND.
@@ -3625,7 +3625,7 @@ make the entries undoable as a single action. See
   "Execute BODY with enabled undo.
 If undo is disabled in the current buffer, the undo information
 is stored in `evil-temporary-undo' instead of `buffer-undo-list'."
-  (declare (debug t))
+  (declare (indent defun) (debug t))
   (let ((undo-list (make-symbol "undo-list")))
     `(let ((,undo-list buffer-undo-list)
            (evil-undo-system evil-undo-system))
@@ -3645,7 +3645,7 @@ is stored in `evil-temporary-undo' instead of `buffer-undo-list'."
 
 (defmacro evil-with-single-undo (&rest body)
   "Execute BODY as a single undo step."
-  (declare (debug t))
+  (declare (indent defun) (debug t))
   `(let (evil-undo-list-pointer)
      (evil-with-undo
        (evil-start-undo-step)
@@ -4000,7 +4000,6 @@ should be left-aligned for left justification."
 ;;; View helper
 
 (defvar-local evil-list-view-select-action nil)
-(put 'evil-list-view-select-action 'permanent-local t)
 
 (define-derived-mode evil-list-view-mode tabulated-list-mode
   "Evil List View"

--- a/evil-states.el
+++ b/evil-states.el
@@ -48,8 +48,7 @@ AKA \"Command\" state."
   "Reset command loop variables in Normal state.
 Also prevent point from reaching the end of the line.
 If the region is activated, enter Visual state."
-  (unless (or (evil-initializing-p)
-              (null this-command))
+  (unless (null this-command)
     (setq command (or command this-command))
     (when (evil-normal-state-p)
       (setq evil-this-type nil
@@ -449,17 +448,13 @@ or `block'."
 SELECTION is a kind of selection as defined by
 `evil-define-visual-selection', such as `char', `line'
 or `block'."
-  (let (message)
-    (setq selection (or selection evil-visual-selection))
-    (when selection
-      (setq message
-            (symbol-value (intern (format "evil-visual-%s-message"
-                                          selection))))
+  (unless selection (setq selection evil-visual-selection))
+  (when selection
+    (let ((message (symbol-value (intern (format "evil-visual-%s-message"
+                                                 selection)))))
       (cond
-       ((functionp message)
-        (funcall message))
-       ((stringp message)
-        (evil-echo "%s" message))))))
+       ((functionp message) (funcall message))
+       ((stringp message) (evil-echo "%s" message))))))
 
 (defun evil-visual-select (beg end &optional type dir message)
   "Create a Visual selection of type TYPE from BEG to END.

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9328,7 +9328,7 @@ parameter set."
 ;;; ESC
 
 (ert-deftest evil-test-esc-count ()
-  "Test if prefix-argument is transfered for key sequences with meta-key"
+  "Test if prefix-argument is transferred for key sequences with meta-key"
   :tags '(evil esc)
   (unless noninteractive
     (ert-info ("Test M-<right>")
@@ -9370,11 +9370,10 @@ parameter set."
   (ert-info ("Execute yanked macro")
     (evil-test-buffer
       "[i]foo\e"
-      ("\"qd$@q\"qp"
-       "fooifoo\e")))
+      ("\"qD@q\"qp"
+      "fooifoo\e")))
   (ert-info ("Paste recorded marco")
     (evil-test-buffer
-      ""
       (evil-set-register ?q (vconcat "ifoo" [escape]))
       ("@q\"qp")
       "fooifoo\e")))
@@ -9453,14 +9452,14 @@ parameter set."
     (ert-info ("Jump across files")
       (let ((temp-file (make-temp-file "evil-test-")))
         (unwind-protect
-          (evil-test-buffer
-            "[z] z z z z z z"
-            ("\M-x" "find-file" [return] temp-file [return] "inew buffer" [escape])
-            "new buffe[r]"
-            ("\C-o")
-            "[z] z z z z z z"
-            ("\C-i")
-            "new buffe[r]")
+            (evil-test-buffer
+              "[z] z z z z z z"
+              ("\M-x" "find-file" [return] temp-file [return] "inew buffer" [escape])
+              "new buffe[r]"
+              ("\C-o")
+              "[z] z z z z z z"
+              ("\C-i")
+              "new buffe[r]")
           (delete-file temp-file)
           (with-current-buffer (get-file-buffer temp-file)
             (set-buffer-modified-p nil))
@@ -9708,7 +9707,7 @@ main(argc, argv) char **argv; {
             ;; is sufficient for `evil-initial-state-for-buffer' to work.
             (should-error (evil-initial-state-for-buffer)))
         (put 'test-1-mode 'derived-mode-parent 'prog-mode))))
-  (defalias 'test-1-alias-mode 'test-1-mode)
+  (defalias 'test-1-alias-mode #'test-1-mode)
   (define-derived-mode test-3-mode test-1-alias-mode "Test3")
   (evil-set-initial-state 'test-1-mode 'insert)
   (ert-info ("Check inheritance from major mode aliases")


### PR DESCRIPTION
This commit fixes some issues surrounding the initialization of Evil.

First of all, since GNU Emacs 26.1 major mode hooks actually do run in Fundamental mode buffers. In any case, manually enabling fundamental-mode correctly instead of turn-on-evil-mode (by setting major-mode default) successfully enables evil-local-mode, as major mode hooks then run. The major-mode variable also never needed to be reset; it is the job of the major mode to set it, as it starts off as fundamental-mode regardless of its default value.

Secondly, while some hooks and variables set up by evil-local-mode were marked as permanent, this did not matter as evil-initialize unconditionally reinitialized evil-local-mode whenever the major mode changed. Fixed by marking them all as permanent and not executing evil-local-mode if it is already enabled.

Closes #1268