### PR TITLE
Fix executing macro infinite times

### DIFF
--- a/evil-ex.el
+++ b/evil-ex.el
@@ -675,8 +675,8 @@ This function interprets special file names like # and %."
   (unless (zerop (length evil-ex-argument))
     (evil-ex-replace-special-filenames evil-ex-argument)))
 
-(defun evil-ex-repeat (count)
-  "Repeat the last ex command."
+(defun evil-ex-repeat (&optional count)
+  "Repeat the last Ex command."
   (interactive "P")
   (when count
     (goto-char (point-min))

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9567,6 +9567,15 @@ Source
       ("ci|testing" [escape])
       "| foo |testing| bar |")))
 
+(ert-deftest evil-test-kbd-macro ()
+  "Test recording and replaying of macros."
+  :tags '(evil kbd-macro)
+  (ert-info ("Execute macro an infinite number of times")
+    (evil-test-buffer "xxx"
+      (evil-set-register ?q "ryl")
+      (error 'end-of-line "\C-u@q")
+      "yyy")))
+
 (ert-deftest evil-test-undo-kbd-macro ()
   "Test if evil can undo the changes made by a keyboard macro
 when an error stops the execution of the macro"


### PR DESCRIPTION
This commit fixes a regression caused by #1549 where you could no longer give a prefix argument to execute the macro in an infinite loop.