### PR TITLE
Use original state for populating shortcut map

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -714,12 +714,12 @@ recursively."
            (beg 0)
            (end 1)
            (found-prefix nil))
-      (while (and (<= end len))
+      (while (<= end len)
         (let* ((seq (substring keys beg end))
                (cmd (key-binding seq)))
           (cond
            ((memq cmd '(undefined nil))
-            (user-error "No command bound to %s" seq))
+            (user-error "No command bound to `%s'" seq))
            ((arrayp cmd) ; keyboard macro, replace command with macro
             (setq keys (vconcat (substring keys 0 beg)
                                 cmd

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -429,7 +429,14 @@ when exiting Operator-Pending state")
                   'bar))
       (evil-test-change-state 'emacs)
       (should-not (eq (lookup-key evil-operator-shortcut-map "b")
-                      'bar)))))
+                      'bar))))
+  (ert-info ("Compute shortcuts with original keymaps")
+    (evil-test-buffer "foo"
+     (define-key evil-normal-state-local-map (kbd "SPC x") #'evil-delete)
+     ;; evil-forward-char in motion map should not shadow the executed
+     ;; evil-delete binding above when populating shortcut map.
+     ((kbd "SPC x x"))
+     "")))
 
 (ert-deftest evil-test-auxiliary-maps ()
   "Test auxiliary keymaps"

--- a/evil-types.el
+++ b/evil-types.el
@@ -305,11 +305,14 @@ directly."
 
 (evil-define-interactive-code "<r>"
   "Untyped motion range (BEG END)."
-  (evil-operator-range))
+  (let ((range (evil-operator-range)))
+    (setcdr (cdr range) nil)
+    range))
 
 (evil-define-interactive-code "<R>"
   "Typed motion range (BEG END TYPE)."
-  (evil-operator-range t))
+  (let ((range (evil-operator-range)))
+    (list (car range) (cadr range) (evil-type range))))
 
 (evil-define-interactive-code "<v>"
   "Typed motion range of visual range(BEG END TYPE).


### PR DESCRIPTION
Changing to Operator-pending state before executing

    (evil-extract-count (this-command-keys))

can give the wrong result since the actual binding used to invoke the operator may not be present in the new state.

Resolves #1073