### PR TITLE
Track composite changes to current insertion text

### DIFF
--- a/evil-states.el
+++ b/evil-states.el
@@ -885,14 +885,13 @@ CORNER defaults to `upper-left'."
 (defun evil-replace-backspace ()
   "Restore character under cursor."
   (interactive)
-  (let (char)
-    (backward-char)
-    (when (assq (point) evil-replace-alist)
-      (setq char (cdr (assq (point) evil-replace-alist)))
-      (save-excursion
-        (delete-char 1)
-        (when char
-          (insert char))))))
+  (backward-char)
+  (let* ((prev (assq (point) evil-replace-alist))
+         (char (cdr prev))
+         (this-command #'evil-replace-backspace))
+    (when prev
+      (delete-char 1)
+      (when char (save-excursion (insert char))))))
 
 (defun evil-update-replace-alist (opoint count chars-to-delete &optional offset)
   "Add CHARS-TO-DELETE chars to evil-replace-alist, starting at OPOINT.

--- a/evil-states.el
+++ b/evil-states.el
@@ -875,11 +875,11 @@ CORNER defaults to `upper-left'."
 (defun evil-replace-pre-command ()
   "Remember the character under point."
   (when (evil-replace-state-p)
-    (unless (assq (point) evil-replace-alist)
-      (add-to-list 'evil-replace-alist
-                   (cons (point)
-                         (unless (eolp)
-                           (char-after)))))))
+    (let ((char (unless (eolp) (char-after)))
+          (prev (assq (point) evil-replace-alist)))
+      (if prev
+          (setcdr prev char)
+        (push (cons (point) char) evil-replace-alist)))))
 (put 'evil-replace-pre-command 'permanent-local-hook t)
 
 (defun evil-replace-backspace ()

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -783,9 +783,16 @@ de[f]
       "abç[d]efgh")
     (ert-info ("with count")
       (evil-test-buffer
-      "abc[d]efgh"
-      ("R\C-u3\C-kd*")
-      "abcδδδ[g]h"))))
+        "abc[d]efgh"
+        ("R\C-u3\C-kd*")
+        "abcδδδ[g]h"))))
+
+(ert-deftest evil-test-track-insertion ()
+  "Test that the text of the previous insertion is tracked."
+  (ert-info ("Moving the cursor starts a new insertion")
+    (evil-test-buffer
+      ("iabc" [left] "xxx" [escape] "o\C-a")
+      "abxxxc\nxxx")))
 
 ;;; Repeat system
 

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7442,6 +7442,10 @@ golf h[o]>tel")))
       ([backspace backspace backspace])
       ";; foo bar\n;; [q]ux quux")
     (define-key evil-replace-state-map (kbd "C-y") nil))
+  (ert-info ("Replace character twice and restore")
+    (evil-test-buffer "[a]"
+      ("Rb" [left] "c" [backspace])
+      "b"))
   (ert-info ("Can give Replace-state a count repeat it")
     (evil-test-buffer
       "a[l]pha bravo"


### PR DESCRIPTION
The implementation of `evil-track-last-insertion` introduced in commit 477fe8e83e58739215ea3b601098ee134484114f assumed that all relevant changes look like atomic insertions/deletions, but e.g. `remove-yank-excluded-properties` upon yanking causes a single substitution change. This commit fixes that.

A change not centered around the end of the previous insertion is also made to start a new range, like in Vim.

Fixes #1759