### PR TITLE
Restore match data after eval:ing replacement

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3912,26 +3912,17 @@ The magic character , (comma) start an Emacs-lisp expression."
       (cons 'replace-eval-replacement
             (car (evil-compile-subreplacement to))))))
 
-(defun evil-replace-match (replacement &optional fixedcase string)
-  "Replace text match by last search with REPLACEMENT.
-If REPLACEMENT is an expression it will be evaluated to compute
-the replacement text, otherwise the function behaves as
-`replace-match'."
-  (if (stringp replacement)
-      (replace-match replacement fixedcase nil string)
-    (replace-match (funcall (car replacement)
-                            (cdr replacement)
-                            0)
-                   fixedcase nil string)))
-
 (defun evil-match-substitute-replacement (replacement &optional fixedcase string)
-  "Return REPLACEMENT as it will be inserted by `evil-replace-match'."
-  (if (stringp replacement)
-      (match-substitute-replacement replacement fixedcase nil string)
-    (match-substitute-replacement (funcall (car replacement)
-                                           (cdr replacement)
-                                           0)
-                                  fixedcase nil string)))
+  "Return REPLACEMENT as it will be inserted by `evil-replace-match'.
+If REPLACEMENT is an expression it will be evaluated to compute the
+replacement text first."
+  (match-substitute-replacement
+   (if (stringp replacement)
+       replacement
+     (funcall (car replacement)
+              (cdr replacement)
+              0))
+   fixedcase nil string))
 
 ;;; Alignment
 

--- a/evil-search.el
+++ b/evil-search.el
@@ -1240,18 +1240,15 @@ This handler highlights the pattern of the current substitution."
 
 (defun evil-ex-pattern-update-replacement (_hl overlay)
   "Update the replacement display."
-  (when (fboundp 'match-substitute-replacement)
-    (let ((fixedcase (not case-replace))
-          repl)
-      (setq repl (if evil-ex-substitute-current-replacement
-                     (evil-match-substitute-replacement
-                      evil-ex-substitute-current-replacement
-                      fixedcase)
-                   ""))
-      (put-text-property 0 (length repl)
-                         'face 'evil-ex-substitute-replacement
-                         repl)
-      (overlay-put overlay 'after-string repl))))
+  (let ((repl (if evil-ex-substitute-current-replacement
+                  (evil-match-substitute-replacement
+                   evil-ex-substitute-current-replacement
+                   (not case-replace))
+                "")))
+    (put-text-property 0 (length repl)
+                       'face 'evil-ex-substitute-replacement
+                       repl)
+    (overlay-put overlay 'after-string repl)))
 
 (defun evil-ex-parse-global (string)
   "Parse STRING as a global argument."

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7890,7 +7890,15 @@ golf h[o]>tel")))
     (evil-test-buffer
       "[f]oo"
       (":s/foo")
-      "")))
+      ""))
+  (ert-info ("Use replace count in substitution")
+    (evil-test-buffer "xx"
+      (":s/./\\#/g")
+      "01"))
+  (ert-info ("Substitute with `calc' Lisp expression")
+    (evil-test-buffer "1 + 2"
+      (":s/.*/\\,(calc-eval \\0)")
+      "3")))
 
 (ert-deftest evil-test-ex-repeat-substitute-replacement ()
   "Test `evil-ex-substitute' with repeating of previous substitutions."


### PR DESCRIPTION
This fixes #1481.

Also pass along the number of the current replacement to function called to generate each replacement, which fixes #1411.