### PR TITLE
Restore the input method on deactivation of evil-local-mode

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -134,6 +134,7 @@
     (remove-hook 'activate-mark-hook 'evil-visual-activate-hook t)
     (remove-hook 'input-method-activate-hook #'evil-activate-input-method t)
     (remove-hook 'input-method-deactivate-hook #'evil-deactivate-input-method t)
+    (activate-input-method evil-input-method)
     (evil-change-state nil)))
 
 ;; Make the variable permanent local.  This is particular useful in

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -9680,6 +9680,26 @@ main(argc, argv) char **argv; {
     (test-3-mode)
     (should (eq evil-state 'insert))))
 
+(ert-deftest evil-test-keep-input-method ()
+  "Test that the input method is preserved when changing the major mode."
+  :tags '(evil core input-method)
+  (cl-flet ((use-german-input-method () (set-input-method "german-prefix")))
+    (unwind-protect
+        (progn
+          (add-hook 'text-mode-hook #'use-german-input-method)
+          (evil-test-buffer
+           "[]"
+           (should (equal evil-input-method nil))
+           ("a\"a" [escape])
+           "\"[a]"
+           (text-mode)
+           (should (equal evil-input-method "german-prefix"))
+           ("a\"a" [escape])
+           "\"a[ä]"
+           (emacs-lisp-mode)
+           (should (equal evil-input-method "german-prefix"))))
+      (remove-hook 'text-mode-hook #'use-german-input-method))))
+
 (provide 'evil-tests)
 
 ;;; evil-tests.el ends here


### PR DESCRIPTION
### Description
This patch ensures that the input method after deactivating evil-local-mode is the same as the input method used for states with a non-nil :input-method property.

This issue was discovered while investigating why [the input method couldn't be set by the agda2-mode while evil was active][1]. As the change in major mode (to agda2-mode) caused evil-local-mode to be disabled and reenabled by `define-globalized-minor-mode evil-mode`, the input method was lost because the default state (i.e. normal state) does have an :input-method property of nil.

In summary this patch fixes [the approach used by agda2-mode][2] and the official recommendation for changing the input method in the [Emacs manual][3], e.g.
```elisp
(add-hook 'text-mode-hook
  (lambda () (set-input-method "german-prefix")))
```

### System information:
- Emacs version: 28.2 (Using Xorg)
- Evil version: 2b2ba3c
  Note: there are two failing tests in 2b2ba3c.

### Reproduction
Run Emacs using `make emacs`
Evaluate the following snippet (e.g. using `M-:`) 
```elisp
(add-hook 'text-mode-hook
  (lambda () (set-input-method "german-prefix")))
```
Open a new buffer with `:new` and enable the text mode (e.g. `M-x text-mode`).
Then type `"a` in insert state.


#### Expected (with this patch)
The character `ä` should be inserted.

#### Actual (without this patch)
The characters `"a` are inserted.

[1]: https://github.com/agda/agda/issues/2141
[2]: https://github.com/agda/agda/blob/37554c46cbd770fa630f9b164e2b543506acbdbc/src/data/emacs-mode/agda2-mode.el#L432
[3]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Select-Input-Method.html