### PR TITLE
Fix: Should not (evil-set-jump previous-pos) jump after evil-jump-forward

### DIFF
--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -313,7 +313,7 @@ change the current buffer."
           (when previous-pos
             (setf (evil-jumps-struct-previous-pos struct) nil)
             (if (and
-                 ;; `evil-jump-backward' and 'evil-jump-forward' needs
+                 ;; `evil-jump-backward' and 'evil-jump-forward' need
                  ;; to be handled specially. When jumping backward
                  ;; multiple times, calling `evil-set-jump' is always
                  ;; wrong: If you jump back twice and we call


### PR DESCRIPTION
Steps to reproduce the issue:

  - Create files `a` `b` `c` with the following content:
    
```
        $ head a b c
        ==> a <==
        b
    
        I'm A
        ==> b <==
        c
    
        I'm B
        ==> c <==
        I'm C
 ```


  - Run `emancs a` to open bufer `a`
  - Press `gf` to jump to bufer `b`
  - Press `gf` to jump to bufer `c`
  - Press `C-o` to jump back to bufer `b`
  - Press `C-o` to jump back to bufer `a`
  - Press `C-i` to jump foward to bufer `b`
  - Press `C-i` to jump foward to bufer `c`, but the window stays on buffer `b` unexpectedly.