### PR TITLE
Improve evil-change's handling of screen-lines

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1696,7 +1696,9 @@ of the block."
       (evil-start-undo-step))
     (funcall delete-func beg end type register yank-handler)
     (cond
-     ((eq type 'line)
+     ((or (eq type 'line)
+          (and (eq type 'screen-line)
+               (> nlines 1)))
       (setq this-command 'evil-change-whole-line) ; for evil-maybe-remove-spaces
       (cond
        ((/= opoint leftmost-point) (evil-insert 1)) ; deletion didn't delete line


### PR DESCRIPTION
When the type is screen-line and multiple real lines are spanned, make evil-change behave like it does for the line type (e.g., by adding and indenting a new line after deletion).

Partially fixes #1407