### PR TITLE
Implement tabmove

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -1201,6 +1201,15 @@ the right edge."
       (message "%s: hscroll-margin = %d" this-command hscroll-margin))
     (evil-scroll-column-left (- dist-from-right-edge (abs (* 2 hscroll-margin))))))
 
+(when (featurep 'tab-bar)
+ (evil-define-command evil-tab-move (index-or-offset relative)
+   "Move the current tab to INDEX-OR-OFFSET. Treat as offset if
+RELATIVE is non-nil."
+   (interactive "<+N>")
+   (if relative
+       (tab-bar-move-tab index-or-offset)
+     (tab-bar-move-tab-to index-or-offset))))
+
 (evil-define-command evil-scroll-start-column ()
   "Scroll the window to position the cursor at the start (left side) of the screen.
 Warn if `hscroll-margin' > 0, as cursor will be `hscroll-margin' chars from

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -577,6 +577,7 @@ included in `evil-insert-state-bindings' by default."
 (evil-ex-define-cmd "red[o]" 'evil-redo)
 
 (when (featurep 'tab-bar)
+  (evil-ex-define-cmd "tabm[ove]" 'evil-tab-move)
   (evil-ex-define-cmd "tabnew" 'tab-bar-new-tab)
   (evil-ex-define-cmd "tabc[lose]" 'tab-bar-close-tab)
   (evil-ex-define-cmd "tabo[nly]" 'tab-bar-close-other-tabs)

--- a/evil-types.el
+++ b/evil-types.el
@@ -342,6 +342,26 @@ If visual state is inactive then those values are nil."
          ((evil-ex-p) nil)
          (t 1))))
 
+(evil-define-interactive-code "<+N>" ()
+  "Prefix argument or ex-arg, converted to number. Allow prefixing
+the number with +/- to indicate that this should be treated as
+a relative value instead of absolute."
+  (list
+   (cond
+    (current-prefix-arg (prefix-numeric-value current-prefix-arg))
+    ((and evil-ex-argument (evil-ex-p))
+     (cond
+      ;; Required, since `string-to-number' parses these as 0.
+      ((string-equal evil-ex-argument "+") 1)
+      ((string-equal evil-ex-argument "-") -1)
+      (t (string-to-number evil-ex-argument))))
+    ((evil-ex-p) nil)
+    (t 1))
+   (cond
+    ((and evil-ex-argument (evil-ex-p))
+     (memq (string-to-char evil-ex-argument) '(?- ?+)))
+    (t nil))))
+
 (evil-define-interactive-code "<f>"
   "Ex file argument."
   :ex-arg file


### PR DESCRIPTION
tabmove allows specifying the index in two ways: either as an aboslute index, or an offset from the current tab prefixed by +/-.