### PR TITLE
tabs: Go to nth tab when tab-next is prefixed

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4782,6 +4782,18 @@ and redisplay the current buffer there."
   :repeat nil
   (evil-move-window 'below))
 
+;;; Tab commands
+
+(evil-define-command evil-tab-next (arg)
+  "Switch to the next tab.
+If ARG is non-nil, parse ARG as an index and go to the tab at that
+index."
+  :repeat nil
+  (interactive "<c>")
+  (if arg
+      (tab-bar-select-tab arg)
+    (tab-bar-switch-to-next-tab)))
+
 ;;; Mouse handling
 
 ;; Large parts of this code are taken from mouse.el which is

--- a/evil-maps.el
+++ b/evil-maps.el
@@ -189,8 +189,8 @@
 (define-key evil-window-map [C-right] 'evil-window-right)
 
 (when (featurep 'tab-bar)
-  (define-key evil-motion-state-map "gt" 'tab-bar-switch-to-next-tab)
-  (define-key evil-window-map "gt" 'tab-bar-switch-to-next-tab)
+  (define-key evil-motion-state-map "gt" 'evil-tab-next)
+  (define-key evil-window-map "gt" 'evil-tab-next)
   (define-key evil-motion-state-map "gT" 'tab-bar-switch-to-prev-tab)
   (define-key evil-window-map "gT" 'tab-bar-switch-to-prev-tab))
 
@@ -588,7 +588,7 @@ included in `evil-insert-state-bindings' by default."
   (evil-ex-define-cmd "tabnew" 'tab-bar-new-tab)
   (evil-ex-define-cmd "tabc[lose]" 'tab-bar-close-tab)
   (evil-ex-define-cmd "tabo[nly]" 'tab-bar-close-other-tabs)
-  (evil-ex-define-cmd "tabn[ext]" 'tab-bar-switch-to-next-tab)
+  (evil-ex-define-cmd "tabn[ext]" 'evil-tab-next)
   (evil-ex-define-cmd "tabp[revious]" 'tab-bar-switch-to-prev-tab))
 
 ;; Command-line editing


### PR DESCRIPTION
This emulates the behavior of vim, where {N}gt goes to the Nth tab, but {N}gT goes back N tabs.