### PR TITLE
Fix pasting in visual block mode

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2251,6 +2251,13 @@ leave the cursor just after the new text."
         evil--cursor-after t)
   (evil-paste-after count register yank-handler))
 
+(defun evil-insert-for-yank-at-col (startcol _endcol string count)
+  "Insert STRING at STARTCOL."
+  (move-to-column startcol)
+  (dotimes (_ (or count 1))
+    (insert-for-yank string))
+  (evil-set-marker ?\] (1- (point))))
+
 (evil-define-command evil-visual-paste (count &optional register)
   "Paste over Visual selection."
   :suppress-operator t
@@ -2296,12 +2303,7 @@ leave the cursor just after the new text."
            ((and (eq type 'block)
                  (not (eq yank-handler #'evil-yank-block-handler))
                  (not (string-match-p "\n" text)))
-            (evil-apply-on-block
-             (lambda (startcol _endcol string count)
-               (move-to-column startcol)
-               (dotimes (_ count) (insert-for-yank string))
-               (evil-set-marker ?\] (1- (point))))
-             beg end t text count))
+            (evil-apply-on-block #'evil-insert-for-yank-at-col beg end t text count))
            (t (evil-paste-before count register)))))
       (when evil-kill-on-visual-paste
         (current-kill -1))

--- a/evil-states.el
+++ b/evil-states.el
@@ -759,10 +759,9 @@ the direction of the last selection."
 (defun evil-visual-type (&optional selection)
   "Return the type of the Visual selection.
 If SELECTION is specified, return the type of that instead."
-  (if (and (null selection) (evil-visual-state-p))
-      (or evil-this-type (evil-visual-type evil-visual-selection))
-    (setq selection (or selection evil-visual-selection))
-    (symbol-value (cdr-safe (assq selection evil-visual-alist)))))
+  (or (and (null selection) (evil-visual-state-p) evil-this-type)
+      (symbol-value (cdr (assq (or selection evil-visual-selection)
+                               evil-visual-alist)))))
 
 (defun evil-visual-goto-end ()
   "Go to the last line of the Visual selection.

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -3039,10 +3039,13 @@ word3[]"))
       ("gv") ;; Test point & mark are stored correctly
       "abc\n1<abcabc3\n1abcabc3\n1abcab[c]>3"))
   (ert-info ("Blockwise visual paste of linewise text")
-    (evil-test-buffer
-      "[a]bc\n123\n123\n123"
-      ("yy" "jl" "\C-vG" "p")
-      "abc\n1\nabc\n3\n1\nabc\n3\n1\nabc\n3")))
+    (evil-test-buffer "[a]bc\n123\n123"
+      ("yy" "jl" "\C-vj" "p")
+      "abc\n13\n13\nabc"))
+  (ert-info ("Blockwise visual paste of blockwise text")
+    (evil-test-buffer "xy\n[z]\n123\n123"
+      ("\C-vkly2jl\C-vjp")
+      "xy\nz\n1xy3\n1z 3")))
 
 (ert-deftest evil-test-visual-paste-pop ()
   "Test `evil-paste-pop' after visual paste."


### PR DESCRIPTION
Repeating the pasted text for each line of the blockwise selection should only be done when the replacement text is characterwise and just a single line.

Resolves #1785