### PR TITLE
Silence native-comp warnings

### DIFF
--- a/evil-command-window.el
+++ b/evil-command-window.el
@@ -164,7 +164,7 @@ function to execute."
           (push result evil-search-backward-history)))
       (evil-search result forward evil-regexp-search))))
 
-(defun evil-command-window-draw-prefix (&rest ignored)
+(defun evil-command-window-draw-prefix (&rest _ignored)
   "Display `evil-command-window-cmd-key' as a prefix to the current line.
 Parameters passed in through IGNORED are ignored."
   (let ((prefix (propertize evil-command-window-cmd-key

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2145,7 +2145,7 @@ the current line."
   (interactive "<c>")
   (if (and (eq 'self-insert-command last-command)
            (eq ?0 (char-before)))
-      (progn (backward-delete-char 1)
+      (progn (delete-char -1)
              (evil-delete-indentation))
     (evil-shift-left (line-beginning-position) (line-beginning-position 2) count t)))
 
@@ -3049,8 +3049,8 @@ Calls `evil-complete-previous-line-func'."
 
 (defun evil-repeat-search (flag)
   "Called to record a search command.
-FLAG is either 'pre or 'post if the function is called before resp.
-after executing the command."
+FLAG is either \\='pre or \\='post if the function is called
+before resp, after executing the command."
   (cond
    ((and (evil-operator-state-p) (eq flag 'pre))
     (evil-repeat-record (this-command-keys))
@@ -3842,8 +3842,8 @@ Change to `%s'? "
 
 (defun evil-repeat-ex-search (flag)
   "Called to record a search command.
-FLAG is either 'pre or 'post if the function is called before
-resp.  after executing the command."
+FLAG is either \\='pre or \\='post if the function is called
+before resp, after executing the command."
   (cond
    ((and (evil-operator-state-p) (eq flag 'pre))
     (evil-repeat-record (this-command-keys))
@@ -4134,6 +4134,7 @@ This is the same as \":%s//~/&\"."
   (apply #'evil-ex-substitute (point-min) (point-max)
          (evil-ex-get-substitute-info (concat "//~/&"))))
 
+(declare-function hi-lock-read-face-name "hi-lock")
 (evil-define-command evil-ex-match (args &optional bang)
   "Define a pattern to highlight in the current buffer.
 With no args, clear a highlight from the buffer

--- a/evil-common.el
+++ b/evil-common.el
@@ -96,7 +96,7 @@ otherwise prepend it to the list.
   "Delete by side-effect all items satisfying PREDICATE in LIST.
 Stop when reaching POINTER.  If the first item satisfies PREDICATE,
 there is no way to remove it by side-effect; therefore, write
-\(setq foo (evil-filter-list 'predicate foo)) to be sure of
+(setq foo (evil-filter-list \\='predicate foo)) to be sure of
 changing the value of `foo'."
   (let ((tail list) elt head)
     (while (and tail (not (eq tail pointer)))
@@ -2675,7 +2675,7 @@ list of command properties as passed to `evil-define-command'."
 
 (defun evil-set-type (object type)
   "Set the type of OBJECT to TYPE.
-For example, (evil-set-type 'next-line 'line)
+For example, (evil-set-type \\='next-line \\='line)
 will make `line' the type of the `next-line' command."
   (cond
    ((overlayp object)
@@ -3012,10 +3012,10 @@ linewise, otherwise it is character wise."
 OP and CL are pairs of buffer positions for the opening and
 closing delimiter of a range. SELECTION-TYPE is the desired type
 of selection.  It is a symbol that determines which parts of the
-block are selected.  If it is 'inclusive or t the returned range
-is \(cons (car OP) (cdr CL)). If it is 'exclusive or nil the
-returned range is (cons (cdr OP) (car CL)).  If it is
-'exclusive-line the returned range will skip whitespace at the
+block are selected.  If it is \\='inclusive or t the returned
+range is (cons (car OP) (cdr CL)). If it is \\='exclusive or nil
+the returned range is (cons (cdr OP) (car CL)).  If it is
+\\='exclusive-line the returned range will skip whitespace at the
 end of the line of OP and at the beginning of the line of CL."
   (cond
    ((memq selection-type '(inclusive t)) (cons (car op) (cdr cl)))
@@ -3048,13 +3048,14 @@ delimited object must be given by THING-up function (see
 `evil-up-block').
 
 SELECTION-TYPE is symbol that determines which parts of the block
-are selected.  If it is 'inclusive or t OPEN and CLOSE are
-included in the range. If it is 'exclusive or nil the delimiters
-are not contained. If it is 'exclusive-line the delimiters are
-not included as well as adjacent whitespace until the beginning
-of the next line or the end of the previous line. If the
-resulting selection consists of complete lines only and visual
-state is not active, the returned selection is linewise.
+are selected.  If it is \\='inclusive or t OPEN and CLOSE are
+included in the range. If it is \\='exclusive or nil the
+delimiters are not contained. If it is \\='exclusive-line the
+delimiters are not included as well as adjacent whitespace until
+the beginning of the next line or the end of the previous
+line. If the resulting selection consists of complete lines only
+and visual state is not active, the returned selection is
+linewise.
 
 If COUNTCURRENT is non-nil an objected is counted if the current
 selection matches that object exactly.
@@ -3229,7 +3230,7 @@ is ignored."
 
 (defun evil-select-quote-thing (thing beg end _type count &optional inclusive)
   "Selection THING as if it described a quoted object.
-THING is typically either 'evil-quote or 'evil-chars. This
+THING is typically either \\='evil-quote or \\='evil-chars. This
 function is called from `evil-select-quote'."
   (save-excursion
     (let* ((count (or count 1))
@@ -3666,8 +3667,8 @@ Depending on the value of MAGIC the following characters are
 considered magic.
   t             [][{}*+?.&~$^
   nil           [][{}*+?$^
-  'very-magic   not 0-9A-Za-z_
-  'very-nomagic empty."
+  \\='very-magic   not 0-9A-Za-z_
+  \\='very-nomagic empty."
   (cond
    ((eq magic t) "[][}{*+?.&~$^]")
    ((eq magic 'very-magic) "[^0-9A-Za-z_]")
@@ -3773,10 +3774,10 @@ replacement text first."
 (defun evil-justify-lines (beg end justify position)
   "Justify all lines in a range.
 BEG and END specify the range of those lines to be
-justified. JUSTIFY is either 'left, 'right or 'center according
-to the justification type. POSITION is the maximal text width for
-right and center justification or the column at which the lines
-should be left-aligned for left justification."
+justified. JUSTIFY is either \\='left, \\='right or \\='center
+according to the justification type. POSITION is the maximal text
+width for right and center justification or the column at which
+the lines should be left-aligned for left justification."
   (let ((fill-column position)
         adaptive-fill-mode fill-prefix)
     (evil-with-restriction

--- a/evil-core.el
+++ b/evil-core.el
@@ -556,7 +556,7 @@ Enable with positive ARG and disable with negative ARG.
 
 When enabled, `evil-esc-mode' modifies the entry of \\e in
 `input-decode-map'. If such an event arrives, it is translated to
-a plain 'escape event if no further event occurs within
+a plain \\='escape event if no further event occurs within
 `evil-esc-delay' seconds. Otherwise no translation happens and
 the ESC prefix map (i.e. the map originally bound to \\e in
 `input-decode-map`) is returned."
@@ -599,17 +599,17 @@ the ESC prefix map (i.e. the map originally bound to \\e in
             (set-terminal-parameter term 'evil-esc-map nil)))))))
 
 (defun evil-esc (map)
-  "Translate \\e to 'escape if no further event arrives.
-This function is used to translate a \\e event either to 'escape
-or to the standard ESC prefix translation map. If \\e arrives,
-this function waits for `evil-esc-delay' seconds for another
-event. If no other event arrives, the event is translated to
-'escape, otherwise it is translated to the standard ESC prefix
-map stored in `input-decode-map'. If `evil-inhibit-esc' is
+  "Translate \\e to \\='escape if no further event arrives.
+This function is used to translate a \\e event either to
+\\='escape or to the standard ESC prefix translation map. If \\e
+arrives, this function waits for `evil-esc-delay' seconds for
+another event. If no other event arrives, the event is translated
+to \\='escape, otherwise it is translated to the standard ESC
+prefix map stored in `input-decode-map'. If `evil-inhibit-esc' is
 non-nil or if evil is in emacs state, the event is always
 translated to the ESC prefix.
 
-The translation to 'escape happens only if the current command
+The translation to \\='escape happens only if the current command
 has indeed been triggered by \\e. In other words, this will only
 happen when the keymap is accessed from `read-key-sequence'. In
 particular, if it is access from `define-key' the returned
@@ -940,21 +940,21 @@ these. Omitting a state by using `nil' corresponds to a standard
 Emacs binding using `define-key'. The remaining arguments are
 like those of `define-key'. For example:
 
-    (evil-define-key 'normal foo-map \"a\" 'bar)
+    (evil-define-key \\='normal foo-map \"a\" \\='bar)
 
 This creates a binding from `a' to `bar' in normal state, which
 is active whenever `foo-map' is active. Using nil for the state,
 the following lead to identical bindings:
 
-    (evil-define-key nil foo-map \"a\" 'bar)
-    (define-key foo-map \"a\" 'bar)
+    (evil-define-key nil foo-map \"a\" \\='bar)
+    (define-key foo-map \"a\" \\='bar)
 
 It is possible to specify multiple states and/or bindings at
 once:
 
-    (evil-define-key '(normal visual) foo-map
-      \"a\" 'bar
-      \"b\" 'foo)
+    (evil-define-key \\='(normal visual) foo-map
+      \"a\" \\='bar
+      \"b\" \\='foo)
 
 If `foo-map' has not been initialized yet, this macro adds an
 entry to `after-load-functions', delaying execution as necessary.
@@ -963,8 +963,8 @@ KEYMAP may also be a quoted symbol. If the symbol is `global', the
 global evil keymap corresponding to the state(s) is used, meaning
 the following lead to identical bindings:
 
-    (evil-define-key 'normal 'global \"a\" 'bar)
-    (evil-global-set-key 'normal \"a\" 'bar)
+    (evil-define-key \\='normal \\='global \"a\" \\='bar)
+    (evil-global-set-key \\='normal \"a\" \\='bar)
 
 The symbol `local' may also be used, which corresponds to using
 `evil-local-set-key'. If a quoted symbol is used that is not
@@ -996,30 +996,30 @@ state by using nil corresponds to a standard Emacs binding using
 `define-key' The remaining arguments are like those of
 `define-key'. For example:
 
-    (evil-define-key* 'normal foo-map \"a\" 'bar)
+    (evil-define-key* \\='normal foo-map \"a\" \\='bar)
 
 This creates a binding from \"a\" to bar in Normal state, which
 is active whenever foo-map is active. Using nil for the state,
 the following are equivalent:
 
-    (evil-define-key* nil foo-map \"a\" 'bar)
+    (evil-define-key* nil foo-map \"a\" \\='bar)
 
-    (define-key foo-map \"a\" 'bar)
+    (define-key foo-map \"a\" \\='bar)
 
  It is possible to specify multiple states and/or bindings at
  once:
 
-    (evil-define-key* '(normal visual) foo-map
-      \"a\" 'bar
-      \"b\" 'foo)
+    (evil-define-key* \\='(normal visual) foo-map
+      \"a\" \\='bar
+      \"b\" \\='foo)
 
 KEYMAP may also be a quoted symbol. If the symbol is global, the
 global evil keymap corresponding to the state(s) is used, meaning
 the following are equivalent:
 
-    (evil-define-key* 'normal 'global \"a\" 'bar)
+    (evil-define-key* \\='normal \\='global \"a\" \\='bar)
 
-    (evil-global-set-key 'normal \"a\" 'bar)
+    (evil-global-set-key \\='normal \"a\" \\='bar)
 
 The symbol local may also be used, which corresponds to using
 `evil-local-set-key'.

--- a/evil-ex.el
+++ b/evil-ex.el
@@ -147,8 +147,8 @@ The result is a function taking the arguments STRING, SYMBOL and
 SYNTAX, that parses STRING. SYMBOL should be one of ENTRYPOINTS.
 
 If the parse succeeds, the return value is a cons cell
-\(RESULT . END), where RESULT is a parse tree and END is the start of
-the remainder of STRING. Otherwise, the return value is nil.
+(RESULT . END), where RESULT is a parse tree and END is the start
+of the remainder of STRING. Otherwise, the return value is nil.
 
 GRAMMAR is an association list of symbols and their definitions.
 A definition is a list of production rules, which are tried in
@@ -168,8 +168,8 @@ A production rule can be one of the following:
 
 Thus, a simple grammar may look like:
 
-    ((plus \"\\\\+\")       ; plus <- \"+\"
-     (minus \"-\")          ; minus <- \"-\"
+    ((plus \"\\\\+\")           ; plus <- \"+\"
+     (minus \"-\")            ; minus <- \"-\"
      (operator plus minus)) ; operator <- plus / minus
 
 All input-consuming rules have a value. A regular expression evaluates
@@ -177,18 +177,18 @@ to the text matched, while a list evaluates to a list of values.
 The value of a list may be overridden with a semantic action, which is
 specified with a #'-quoted expression at the end:
 
-    (X Y #'foo)
+    (X Y #\\='foo)
 
 The value of this rule is the result of calling foo with the values
 of X and Y as arguments. Alternatively, the function call may be
 specified explicitly:
 
-    (X Y #'(foo $1 $2))
+    (X Y #\\='(foo $1 $2))
 
 Here, $1 refers to X and $2 refers to Y. $0 refers to the whole list.
 Dollar expressions can also be used directly:
 
-    (X Y #'$1)
+    (X Y #\\='$1)
 
 This matches X followed by Y, but ignores the value of Y;
 the value of the list is the same as the value of X.
@@ -694,14 +694,14 @@ keywords and function:
   Function to be called when the type of the current argument
   changes or when the content of this argument changes. This
   function should take one obligatory argument FLAG followed by
-  an optional argument ARG. FLAG is one of three symbol 'start,
-  'stop or 'update. When the argument type is recognized for the
-  first time and this handler is started the FLAG is 'start. If
-  the argument type changes to something else or ex state
-  finished the handler FLAG is 'stop. If the content of the
-  argument has changed FLAG is 'update. If FLAG is either 'start
-  or 'update then ARG is the current value of this argument. If
-  FLAG is 'stop then arg is nil."
+  an optional argument ARG. FLAG is one of three symbol
+  \\='start, \\='stop or \\='update. When the argument type is
+  recognized for the first time and this handler is started the
+  FLAG is \\='start. If the argument type changes to something
+  else or ex state finished the handler FLAG is \\='stop. If the
+  content of the argument has changed FLAG is \\='update. If FLAG
+  is either \\='start or \\='update then ARG is the current value
+  of this argument. If FLAG is \\='stop then arg is nil."
   (declare (indent defun)
            (doc-string 2)
            (debug (&define name

--- a/evil-search.el
+++ b/evil-search.el
@@ -305,7 +305,7 @@ otherwise for the word at point."
 (defun evil--find-thing (forward thing)
   "Return a cons of THING near point as a string and its position.
 THING should be a symbol understood by `thing-at-point',
-e.g. 'symbol or 'word.  If FORWARD is nil, search backward,
+e.g. \\='symbol or \\='word.  If FORWARD is nil, search backward,
 otherwise forward.  Returns nil if nothing is found."
   (let ((move (if forward #'forward-char #'backward-char))
         (end (if forward #'eobp #'bobp))
@@ -325,7 +325,7 @@ otherwise forward.  Returns nil if nothing is found."
 (defun evil-find-thing (forward thing)
   "Return a THING near point as a string.
 THING should be a symbol understood by `thing-at-point',
-e.g. 'symbol or 'word.  If FORWARD is nil, search backward,
+e.g. \\='symbol or \\='word.  If FORWARD is nil, search backward,
 otherwise forward.  Returns nil if nothing is found."
   (car (evil--find-thing forward thing)))
 
@@ -420,7 +420,7 @@ This function respects the values of `evil-ex-search-case'."
 (defun evil-ex-make-pattern (regexp case whole-line)
   "Create a new search pattern.
 REGEXP is the regular expression to be searched for. CASE should
-be either 'sensitive, 'insensitive for case-sensitive and
+be either \\='sensitive, \\='insensitive for case-sensitive and
 case-insensitive search, respectively, or anything else.  In the
 latter case the pattern is smart-case, i.e. it is automatically
 sensitive of the pattern contains one upper case letter,
@@ -754,14 +754,14 @@ the direcion is determined by `evil-ex-search-direction'."
 (defun evil-ex-find-next (&optional pattern direction nowrap)
   "Search for the next occurrence of the PATTERN in DIRECTION.
 PATTERN must be created using `evil-ex-make-pattern', DIRECTION
-is either 'forward or 'backward. If NOWRAP is non nil, the search
-does not wrap at buffer boundaries. Furthermore this function
-only searches invisible text if `search-invisible' is t. If
-PATTERN is not specified the current global pattern
+is either \\='forward or \\='backward. If NOWRAP is non nil, the
+search does not wrap at buffer boundaries. Furthermore this
+function only searches invisible text if `search-invisible' is
+t. If PATTERN is not specified the current global pattern
 `evil-ex-search-pattern' and if DIRECTION is not specified the
 current global direction `evil-ex-search-direction' is used.
 This function returns t if the search was successful, nil if it
-was unsuccessful and 'wrapped if the search was successful but
+was unsuccessful and \\='wrapped if the search was successful but
 has been wrapped at the buffer boundaries."
   (setq pattern (or pattern evil-ex-search-pattern)
         direction (or direction evil-ex-search-direction))
@@ -877,8 +877,8 @@ Return a triple (regexp offset next-search)."
   "Search for a full search pattern PATTERN-STRING in DIRECTION.
 This function splits PATTERN-STRING into
 pattern/offset/;next-pattern parts and performs the search in
-DIRECTION which must be either 'forward or 'backward. The first
-search is repeated COUNT times. If the pattern part of
+DIRECTION which must be either \\='forward or \\='backward. The
+first search is repeated COUNT times. If the pattern part of
 PATTERN-STRING is empty, the last global pattern stored in
 `evil-ex-search-pattern' is used instead if in addition the
 offset part is nil (i.e. no pattern/offset separator), the last
@@ -888,8 +888,8 @@ successful match.  This function returns a triple (RESULT PATTERN
 OFFSET) where RESULT is
 
   t              the search has been successful without wrap
-  'wrap          the search has been successful with wrap
-  'empty-pattern the last pattern has been empty
+  \\='wrap          the search has been successful with wrap
+  \\='empty-pattern the last pattern has been empty
   nil            the search has not been successful
 
 and PATTERN and OFFSET are the last pattern and offset this
@@ -1201,16 +1201,16 @@ This handler highlights the pattern of the current substitution."
 
 (defun evil-ex-get-substitute-info (string &optional implicit-r)
   "Return the substitution info of command line STRING.
-This function returns a three-element list \(PATTERN REPLACEMENT
+This function returns a three-element list (PATTERN REPLACEMENT
 FLAGS) consisting of the substitution parts of STRING. PATTERN is
 a ex-pattern (see `evil-ex-make-pattern') and REPLACEMENT in a
 compiled replacement expression (see `evil-compile-replacement').
 The information returned is the actual substitution information
 w.r.t. to special situations like empty patterns or repetition of
 previous substitution commands. If IMPLICIT-R is non-nil, then
-the flag 'r' is assumed, i.e. in the case of an empty pattern the
-last search pattern is used. This will be used when called from
-a :substitute command with arguments."
+the flag `r' is assumed, i.e. in the case of an empty pattern the
+last search pattern is used. This will be used when called from a
+:substitute command with arguments."
   (let (pattern replacement flags)
     (cond
      ((or (null string) (string-match "^[a-zA-Z]" string))

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -407,7 +407,7 @@ also be inhibited by setting `evil-inhibit-esc'."
 Used by `evil-esc-mode'.")
 
 (defvar evil-inhibit-esc nil
-  "If non-nil, the \\e event will never be translated to 'escape.")
+  "If non-nil, the \\e event will never be translated to \\='escape.")
 
 (defcustom evil-intercept-esc 'always
   "Whether Evil should intercept the escape key.
@@ -1252,8 +1252,8 @@ only has influence if the Evil search module is chosen in
   "If non-nil Vim-style backslash codes are supported in search patterns.
 See `evil-transform-vim-style-regexp' for the supported backslash
 codes.  Note that this only affects the search command if
-`evil-search-module' is set to 'evil-search. The isearch module
-always uses plain Emacs regular expressions."
+`evil-search-module' is set to \\='evil-search. The isearch
+module always uses plain Emacs regular expressions."
   :type 'boolean
   :group 'evil)
 
@@ -1298,7 +1298,7 @@ used."
 
 (defcustom evil-ex-search-incremental t
   "If t, use incremental search. Note that this only affects the
-search command if `evil-search-module' is set to 'evil-search."
+search command if `evil-search-module' is set to \\='evil-search."
   :type 'boolean
   :group 'evil)
 
@@ -1322,10 +1322,10 @@ the replacement is shown interactively."
 (defcustom evil-ex-substitute-global nil
   "If non-nil substitute patterns are global by default.
 Usually (if this variable is nil) a substitution works only on
-the first match of a pattern in a line unless the 'g' flag is
+the first match of a pattern in a line unless the `g' flag is
 given, in which case the substitution happens on all matches in a
 line. If this option is non-nil, this behaviour is reversed: the
-substitution works on all matches unless the 'g' pattern is
+substitution works on all matches unless the `g' pattern is
 specified, then is works only on the first match."
   :type  'boolean
   :group 'evil)
@@ -1855,7 +1855,7 @@ the format:
 MODES acts as a predicate, containing the symbols of all major or
 minor modes for which the handler should match.  For example:
 
-  '((outline-minor-mode org-mode) ...)
+  \\='((outline-minor-mode org-mode) ...)
 
 would match for either outline-minor-mode or org-mode, even though the
 former is a minor mode and the latter is a major.
@@ -1965,7 +1965,7 @@ See `evil-ex-init-shell-argument-completion'.")
   "The history for the search command.")
 
 (defvar evil-ex-search-direction nil
-  "The direction of the current search, either 'forward or 'backward.")
+  "The direction of the current search, either \\='forward or \\='backward.")
 
 (defvar evil-ex-search-count nil
   "The count of the current search.")
@@ -2086,7 +2086,7 @@ This variable must be set before evil is loaded."
 Customized via `evil-undo-system'.")
 
 (defvar evil-redo-function 'evil--redo-placeholder
-  "Function to be used by 'evil-redo'.
+  "Function to be used by `evil-redo'.
 Customized via `evil-undo-system'.")
 
 (defun evil-set-undo-system (system)


### PR DESCRIPTION
On Emacs29, the native compilation warnings are annoying after I update evil.

So I write this pr, there is no changes in evil's actual effect, just for the silence.