### PR TITLE
Make evil-search-wrap-ring-bell work with evil-search

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -739,6 +739,7 @@ the direcion is determined by `evil-ex-search-direction'."
          ((eq res 'wrapped) (setq wrapped t)))))
     (if wrapped
         (let (message-log-max)
+          (when evil-search-wrap-ring-bell (ding))
           (message "Search wrapped")))
     (goto-char (match-beginning 0))
     (setq evil-ex-search-match-beg (match-beginning 0)


### PR DESCRIPTION
evil-search-wrap-ring-bell only worked when evil-search-module was isearch. Make it work with evil-search as well.