### PR TITLE
add keep-active-mark property to states

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -1168,7 +1168,8 @@ the local keymap will be `evil-test-state-local-map', and so on.
          (modes (intern (format "%s-modes" toggle)))
          (predicate (intern (format "%s-p" toggle)))
          arg cursor-value enable entry-hook-value exit-hook-value
-         input-method key message-value suppress-keymap tag-value)
+         input-method key message-value suppress-keymap tag-value
+         keep-active-mark)
     ;; collect keywords
     (while (keywordp (car-safe body))
       (setq key (pop body)
@@ -1193,7 +1194,9 @@ the local keymap will be `evil-test-state-local-map', and so on.
        ((eq key :input-method)
         (setq input-method arg))
        ((eq key :suppress-keymap)
-        (setq suppress-keymap arg))))
+        (setq suppress-keymap arg))
+       ((eq key :keep-active-mark)
+        (setq keep-active-mark arg))))
 
     ;; macro expansion
     `(progn
@@ -1235,7 +1238,8 @@ cursor, or a list of the above." name))
                               ,(format "Modes that should come up in %s." name))
                      :input-method ',input-method
                      :predicate ',predicate
-                     :enable ',enable)))
+                     :enable ',enable
+                     :keep-active-mark ',keep-active-mark)))
        (evil--add-to-alist evil-state-properties ',state plist))
 
        ,@(when suppress-keymap

--- a/evil-states.el
+++ b/evil-states.el
@@ -112,6 +112,7 @@ commands opening a new line."
   :entry-hook (evil-start-track-last-insertion)
   :exit-hook (evil-cleanup-insert-state evil-stop-track-last-insertion)
   :input-method t
+  :keep-active-mark t
   (cond
    ((evil-insert-state-p)
     (add-hook 'post-command-hook #'evil-maybe-remove-spaces)
@@ -278,6 +279,7 @@ the selection is enabled.
   :tag 'evil-visual-tag
   :enable (motion normal)
   :message 'evil-visual-message
+  :keep-active-mark t
   (cond
    ((evil-visual-state-p)
     (evil-save-transient-mark-mode)
@@ -384,9 +386,7 @@ otherwise exit Visual state."
     (evil-delay nil
         ;; the activation may only be momentary, so re-check
         ;; in `post-command-hook' before entering Visual state
-        '(unless (or (evil-visual-state-p)
-                     (evil-insert-state-p)
-                     (evil-emacs-state-p))
+        '(unless (evil-state-property evil-state :keep-active-mark)
            (when (and (region-active-p)
                       (not deactivate-mark))
              (evil-visual-state)))
@@ -909,7 +909,8 @@ Decrement recorded position by optional offset, or 0."
   :tag " <E> "
   :message "-- EMACS --"
   :input-method t
-  :intercept-esc nil)
+  :intercept-esc nil
+  :keep-active-mark t)
 
 (provide 'evil-states)
 


### PR DESCRIPTION
This property is used to determine whether we should enter visual state when the mark is activated. This is useful for states like emacs state where we want to keep the mark active but not enter visual state. This change enables users to customize this behavior for their own states.

This addresses issue https://github.com/gridaphobe/evil-god-state/issues/4 in `evil-god-state`.