### PR TITLE
Fix Vim URL in docs

### DIFF
--- a/doc/build/texinfo/evil.texi
+++ b/doc/build/texinfo/evil.texi
@@ -120,7 +120,7 @@ features of Vim, @footnote{@w{(1)}
 Vim is the most popular version of @emph{vi}, a modal text editor
 with many implementations.  Vim also adds some functions of its
 own, like visual selection and text objects.  For more information
-see @uref{https://vim.org,the official Vim website}.
+see @uref{https://www.vim.org,the official Vim website}.
 } turning Emacs into a modal editor.  Like Emacs in
 general, Evil is extensible in Emacs Lisp.
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -114,4 +114,4 @@ Emacs state (``<E>``)
 .. [#vim] Vim is the most popular version of *vi*, a modal text editor
    with many implementations.  Vim also adds some functions of its
    own, like visual selection and text objects.  For more information
-   see `the official Vim website <https://vim.org>`_.
+   see `the official Vim website <https://www.vim.org>`_.


### PR DESCRIPTION
The URL [`https://vim.org`](https://vim.org) fails to resolve; this PR replaces the two instances of that in the docs to [`https://www.vim.org`](https://www.vim.org) which behaves as expected. This is already correct in [`README.md:12`](https://github.com/emacs-evil/evil/blob/master/README.md?plain=1#L12).