### PR TITLE
(Failing) test for `&` with very-magic vim-style backreferences

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -1158,7 +1158,7 @@ special situations like empty patterns or repetition of previous
 substitution commands. If IMPLICIT-R is non-nil, then the \"r\" flag
 is assumed, i.e. in case of an empty pattern the last search pattern
 is used. It is meant for :substitute commands with arguments."
-  (let (pattern replacement flags)
+  (let (pattern replacement flags using-prev-pattern)
     (cond
      ((or (string= string "") (string-match-p "\\`[a-zA-Z]" string))
       ;; No pattern, since it starts with a letter which cannot be a
@@ -1191,8 +1191,10 @@ is used. It is meant for :substitute commands with arguments."
             (if (eq evil-search-module 'evil-search)
                 (if (and evil-ex-last-was-search (memq ?r flags))
                     (and evil-ex-search-pattern
+                         (setq using-prev-pattern t)
                          (evil-ex-pattern-regex evil-ex-search-pattern))
                   (and evil-ex-substitute-pattern
+                       (setq using-prev-pattern t)
                        (evil-ex-pattern-regex evil-ex-substitute-pattern)))
               (if (eq case-fold-search t)
                   isearch-string
@@ -1200,7 +1202,11 @@ is used. It is meant for :substitute commands with arguments."
             flags (remq ?r flags)))
     ;; generate pattern
     (when pattern
-      (setq pattern (evil-ex-make-substitute-pattern pattern flags)))
+      ;; Disable vim-style regexp conversion if using a previous pattern, because
+      ;; this conversion will already have been done before storing it
+      (let ((evil-ex-search-vim-style-regexp (and evil-ex-search-vim-style-regexp
+                                                  (not using-prev-pattern))))
+        (setq pattern (evil-ex-make-substitute-pattern pattern flags))))
     (list pattern replacement flags)))
 
 (defun evil-ex-nohighlight ()

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -7997,7 +7997,20 @@ golf h[o]>tel")))
       (":s/foo/AAA/g" [return])
       "[x]xx AAA bar AAA bar AAA bar\nxxx foo bar foo bar foo bar"
       ("g&")
-      "xxx AAA bar AAA bar AAA bar\n[x]xx AAA bar AAA bar AAA bar")))
+      "xxx AAA bar AAA bar AAA bar\n[x]xx AAA bar AAA bar AAA bar"))
+  (ert-info ("Repeat magic multiple times")
+    (let ((evil-magic 'very-magic)
+          (evil-ex-search-vim-style-regexp t))
+      (evil-test-buffer
+        "[b]ravo, alpha\ndelta, charlie\nfoxtrot, echo\nhotel, golf"
+        (":s/(.*), (.*)/\\2 \\1" [return])
+        "alpha bravo\ndelta, charlie\nfoxtrot, echo\nhotel, golf"
+        ("j&")
+        "alpha bravo\ncharlie delta\nfoxtrot, echo\nhotel, golf"
+        ("j&")
+        "alpha bravo\ncharlie delta\necho foxtrot\nhotel, golf"
+        ("j&")
+        "alpha bravo\ncharlie delta\necho foxtrot\ngolf hotel"))))
 
 (ert-deftest evil-test-ex-regex-without-case ()
   "Test `evil-ex-regex-without-case'"


### PR DESCRIPTION
@axelf4 I noticed this bug recently and thought surely it must have been introduced recently, but I went back pretty far and could still replicate the bug, so I guess not. Nonetheless, I think you may have been closer to this area of code recently, so if you have any thoughts, feel free to have a stab at the fix. If not, I'll get to it in a few weeks, hopefully. Cheers