### PR TITLE
Fix jumping to next/prev paren/brace from a string is not working

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1360,11 +1360,11 @@ last successful match (that caused COUNT to reach zero)."
                           (cond
                            ((> dir 0)
                             (while (progn
-                                     (up-list dir)
+                                     (up-list dir t)
                                      (/= (char-before) close))))
                            (t
                             (while (progn
-                                     (up-list dir)
+                                     (up-list dir t)
                                      (/= (char-after) open)))))
                         (error (goto-char pnt)))))))
         (cond

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -5874,6 +5874,89 @@ This buffer is for notes."
       ("2])")
       "foo ( { ( bar ) baz } [)]")))
 
+(ert-deftest evil-test-paren-jump-from-string ()
+  "Test jump to next/prev paren from a string"
+  :tags '(evil motion)
+  (evil-test-buffer
+   "{
+  fun(a, \"T[]est\", test());
+}
+"
+   ("[(")
+   "{
+  fun[(]a, \"Test\", test());
+}
+"
+   ("])")
+   "{
+  fun(a, \"Test\", test()[)];
+}
+")
+  (evil-test-buffer
+   "{
+  fun(a, \"T[]est\", test());
+}
+"
+   ("])")
+   "{
+  fun(a, \"Test\", test()[)];
+}
+"
+   ("[(")
+   "{
+  fun[(]a, \"Test\", test());
+}
+")
+  (evil-test-buffer
+   "{
+  fun(a, \"T[]est\", test());
+}
+"
+   ("[{")
+   "[{]
+  fun(a, \"Test\", test());
+}
+")
+  (evil-test-buffer
+   "{
+  fun(a, \"T[]est\", test());
+}
+"
+   ("]}")
+   "{
+  fun(a, \"Test\", test());
+[}]
+"))
+
+(ert-deftest evil-test-paren-jump-inside-string-from-string ()
+  "Test jump to next/prev paren inside string from a string"
+  :tags '(evil motion)
+  (evil-test-buffer
+   "{ (\"Test with paren (inside multi (l[e]vel))\", test()); } "
+   ("[(")
+   "{ (\"Test with paren (inside multi [(]level))\", test()); } "
+   ("[(")
+   "{ (\"Test with paren [(]inside multi (level))\", test()); } ")
+  (evil-test-buffer
+   "{ (\"Test with paren (inside multi (l[e]vel))\", test()); } "
+   ("])")
+   "{ (\"Test with paren (inside multi (level[)])\", test()); } "
+   ("])")
+   "{ (\"Test with paren (inside multi (level)[)]\", test()); } ")
+  (evil-test-buffer
+   "{ (\"Test with paren {inside multi {l[e]vel}}\", test()); } "
+   ("[{")
+   "{ (\"Test with paren {inside multi [{]level}}\", test()); } "
+   ("[{")
+   "{ (\"Test with paren [{]inside multi {level}}\", test()); } ")
+  (evil-test-buffer
+   "{ (\"Test with paren {inside multi {l[e]vel}}\", test()); } "
+   ("]}")
+   "{ (\"Test with paren {inside multi {level[}]}\", test()); } "
+   ("]}")
+   "{ (\"Test with paren {inside multi {level}[}]\", test()); } "))
+
+
 (ert-deftest evil-test-next-mark ()
   "Test `evil-next-mark', `evil-previous-mark'"
   :tags '(evil motion)


### PR DESCRIPTION
Example of test:
```
{
  fun(a, "T[]est", test());
}
```
With cursor at `[]`, the commands `])`, `[(`, `]}` or `[{` don't do anything.

This pull request fixes the problem.