### PR TITLE
Added clarification to evil-define-key for escaping modifier keys

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -958,7 +958,13 @@ the following lead to identical bindings:
 The symbol `local' may also be used, which corresponds to using
 `evil-local-set-key'. If a quoted symbol is used that is not
 `global' or `local', it is assumed to be the name of a minor
-mode, in which case `evil-define-minor-mode-key' is used."
+mode, in which case `evil-define-minor-mode-key' is used.
+
+Bindings that use modifier keys such as `C' or `M' must be escaped
+with a `\\' character as this is a requirement of the `define-key'
+function. For example:
+
+    (evil-define-key \\='normal foo-map \"\\C-a\" \\='bar)"
   (declare (indent defun))
   (cond
    ((member keymap '('global 'local))

--- a/evil-core.el
+++ b/evil-core.el
@@ -960,11 +960,12 @@ The symbol `local' may also be used, which corresponds to using
 `global' or `local', it is assumed to be the name of a minor
 mode, in which case `evil-define-minor-mode-key' is used.
 
-Bindings that use modifier keys such as `C' or `M' must be escaped
-with a `\\' character as this is a requirement of the `define-key'
-function. For example:
+KEY is an internal Emacs representation of a key, as for
+`define-key'. To bind key sequences that use modifier keys such
+as \"C-a\" or \"M-a\", convert the key sequences using `kbd'.
+For example:
 
-    (evil-define-key \\='normal foo-map \"\\C-a\" \\='bar)"
+    (evil-define-key \\='normal foo-map (kbd \"C-a\") \\='bar)"
   (declare (indent defun))
   (cond
    ((member keymap '('global 'local))


### PR DESCRIPTION
It is useful to have clarification in the doc string for evil-define-key that it is necessary to escape modifiers keys, such as "C" and "M", for users that are accustomed to using functions like global-set-key or keymap-global-set where this is not necessary. This is also not made particularly clear in the define-key function itself, which is a legacy function.