### PR TITLE
evil-commands: replace (backward-delete-char) with (delete-char)

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2122,7 +2122,7 @@ the current line."
   (interactive "<c>")
   (if (and (eq 'self-insert-command last-command)
            (eq ?0 (char-before)))
-      (progn (backward-delete-char 1)
+      (progn (delete-char -1)
              (evil-delete-indentation))
     (evil-shift-left (line-beginning-position) (line-beginning-position 2) count t)))
 


### PR DESCRIPTION
Fixes a warning:

    evil-commands.el:2125:15: Warning: ‘backward-delete-char’ is for interactive use only; use ‘delete-char’ instead.