### PR TITLE
evil-types.el: fix deprecation warning for Evil's internal variable

### DIFF
--- a/evil-types.el
+++ b/evil-types.el
@@ -93,7 +93,7 @@ If the end position is at the beginning of a line, then:
 Handling for `evil-want-visual-char-semi-exclusive' is deprecated,
 and will be removed in a future version."
   :expand (lambda (beg end)
-            (if (and evil-want-visual-char-semi-exclusive
+            (if (and (with-no-warnings evil-want-visual-char-semi-exclusive)
                      (evil-visual-state-p)
                      (< beg end)
                      (save-excursion


### PR DESCRIPTION
Split from #1860

This deprecation warning is targeted towards users' configuration. Having it warn about the variable being processed inside Evil is pointless, because of course it is processed in the mode, the mode have to handle it.

So suppress it by wrapping into `(with-no-warnings)`.

Fixes:

```
evil-types.el:96:22: Error: ‘evil-want-visual-char-semi-exclusive’ is an obsolete variable (as of 1.15.0);
```