### PR TITLE
Define documentation dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,14 @@
 version: 2
+
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   apt_packages: [emacs-nox]
   jobs:
     pre_build:
       - scripts/evil-extract-docstrings
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==7.3.7
+sphinx-rtd-theme==2.0.0

--- a/doc/source/_ext/elisp.py
+++ b/doc/source/_ext/elisp.py
@@ -2,15 +2,11 @@ import re
 from os import path
 import json
 
-from docutils import nodes
-from docutils.parsers.rst import Directive
-
 from sphinx import addnodes
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.domains.std import StandardDomain
 from sphinx.directives import ObjectDescription
 from sphinx.roles import XRefRole
-from sphinx.util.docfields import Field
 from sphinx.util.nodes import make_refnode
 
 


### PR DESCRIPTION
Read the Docs stopped installing spinx-rtd-theme by default, which broke documentation builds. This commit fixes that by pinning the required dependencies.

See: https://blog.readthedocs.com/defaulting-latest-build-tools/