### PR TITLE
Don't mutate register when stripping test props during paste

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -2249,9 +2249,10 @@ The return value is the yanked text."
       (let ((evil-kill-on-visual-paste (not evil-kill-on-visual-paste)))
         (evil-visual-paste count register))
     (evil-with-undo
-      (let* ((text (if register
-                       (evil-get-register register)
-                     (current-kill 0)))
+      (let* ((text (copy-sequence
+                    (if register
+                        (evil-get-register register)
+                      (current-kill 0))))
              (yank-handler (or yank-handler
                                (when (stringp text)
                                  (car-safe (get-text-property
@@ -2305,9 +2306,10 @@ The return value is the yanked text."
   (if (evil-visual-state-p)
       (evil-visual-paste count register)
     (evil-with-undo
-      (let* ((text (if register
-                       (evil-get-register register)
-                     (current-kill 0)))
+      (let* ((text (copy-sequence
+                    (if register
+                        (evil-get-register register)
+                      (current-kill 0))))
              (yank-handler (or yank-handler
                                (when (stringp text)
                                  (car-safe (get-text-property

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2750,7 +2750,17 @@ This bufferThis bufferThis buffe[r];; and for Lisp evaluation."))
       ("p")
       ";; This buffer is for notes you don't want to save.[;];
 ;; If you want to create a file, visit that file wi;; th C-x C-f,
-;; then enter the text in that file's own buffer.  ;;")))
+;; then enter the text in that file's own buffer.  ;;"))
+  (ert-info ("Don't mutate register when stripping test props")
+    (let (indent-tabs-mode)
+      (evil-test-buffer
+        "[a]aaaaaaaaaaaa
+bbbbbbbb
+cccc"
+        ("\C-vG$yA       " "\C-r\"" [escape] "up")
+        "aaaaaaaaaaaaa[a]aaaaaaaaaaaa
+bbbbbbbb     bbbbbbbb
+cccc         cccc"))))
 
 (ert-deftest evil-test-paste-after ()
   "Test `evil-paste-after'"


### PR DESCRIPTION
Fixes an issue noticed while triaging #1894