### PR TITLE
Fix cursor colour

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -1279,7 +1279,8 @@ If ARG is nil, don't display a message in the echo area.%s" name doc)
                  (when deactivate-current-input-method-function
                    (deactivate-input-method)))
                (unless evil-no-display
-                 (evil-refresh-cursor ',state)
+                 (when (eq (window-buffer) (current-buffer))
+                   (evil-refresh-cursor ',state))
                  (evil-refresh-mode-line ',state))
                ,@body
                (run-hooks ',entry-hook)


### PR DESCRIPTION
Fixes https://github.com/emacs-evil/evil/issues/502, fixes https://github.com/emacs-evil/evil/issues/1835. Refreshing the cursor when changing the evil state is
only needed (or almost only, see below) when the current buffer is displayed in the
selected window. If this is not the case, and the buffer is only displayed or
its window selected at some later point in time, then `evil-refresh-cursor` will
be called as part of the `window-configuration-change-hook` or as advice to
`select-window`.

However, this introduces the following tiny (and maybe acceptable?) regression:
When doing something like
```elisp
(with-current-buffer some-buffer-displayed-in-another-window
  (some-evil-state-with-a-different-cursor-type))
```
the cursor will not be refreshed in the other window before selecting it. The
cursor colour should indeed not be refreshed, because it is defined for the
whole frame; however, the cursor type should in principle be changed, as it is
defined per buffer and also defines the shape of the cursor in non-selected
windows.

There exist different ways to also handle this case, but they mostly seem ugly
or needlessly complicated to me. I think the most elegant way to fix this would
involve implementing per-buffer cursor colours in Emacs (as suggested in
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=24153d). What do you think?