### PR TITLE
make C-w in ex, search, and eval match insert and replace

### DIFF
--- a/evil-maps.el
+++ b/evil-maps.el
@@ -624,7 +624,7 @@ included in `evil-insert-state-bindings' by default."
 (define-key evil-command-line-map "\C-u" 'evil-delete-whole-line)
 (define-key evil-command-line-map "\C-v" #'quoted-insert)
 (when evil-want-C-w-delete
-  (define-key evil-command-line-map "\C-w" #'backward-kill-word))
+  (define-key evil-command-line-map "\C-w" #'evil-delete-backward-word))
 (define-key evil-command-line-map [escape] #'abort-recursive-edit)
 (define-key evil-command-line-map [S-left] #'backward-word)
 (define-key evil-command-line-map [S-right] #'forward-word)
@@ -653,7 +653,7 @@ included in `evil-insert-state-bindings' by default."
 (define-key evil-eval-map "\C-n" #'next-complete-history-element)
 (define-key evil-eval-map "\C-u" 'evil-delete-whole-line)
 (define-key evil-eval-map "\C-v" #'quoted-insert)
-(define-key evil-eval-map "\C-w" 'backward-kill-word)
+(define-key evil-eval-map "\C-w" 'evil-delete-backward-word)
 (define-key evil-eval-map [escape] 'abort-recursive-edit)
 (define-key evil-eval-map [S-left] 'backward-word)
 (define-key evil-eval-map [S-right] 'forward-word)

--- a/evil-tests.el
+++ b/evil-tests.el
@@ -2222,7 +2222,7 @@ ine3 line3      line3 l\n"))
       "line1\n\n[\n]last line\n")))
 
 (ert-deftest evil-test-delete-backward-word ()
-  "Test `evil-delete-backward-word' in insert & replace states."
+  "Test `evil-delete-backward-word' in insert & replace states, and ex command-line."
   :tags '(evil)
   (ert-info ("evil-delete-backward-word in insert state")
     (let ((evil-backspace-join-lines t))
@@ -2251,7 +2251,12 @@ ine3 line3      line3 l\n"))
       ("\C-w")
       "alpha bravo [c]harlie delta"
       ("\C-w")
-      "alpha [b]ravo charlie delta")))
+      "alpha [b]ravo charlie delta"))
+  (ert-info ("evil-delete-backward-word in ex command-line")
+    (evil-test-buffer
+      ""
+      (":normal i" "one-two" (kbd "C-w") (kbd "C-w") [return])
+      "one")))
 
 (ert-deftest evil-test-visual-X ()
   "Test `X' in visual state."

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -558,11 +558,11 @@ ubiquity of prefix arguments."
            (cond
             ((and (not value)
                   (eq (lookup-key evil-command-line-map (kbd "C-w"))
-                      #'backward-kill-word))
+                      #'evil-delete-backward-word))
              (define-key evil-command-line-map (kbd "C-w") nil))
             ((and value
                   (null (lookup-key evil-command-line-map (kbd "C-w"))))
-             (define-key evil-command-line-map (kbd "C-w") #'backward-kill-word))))
+             (define-key evil-command-line-map (kbd "C-w") #'evil-delete-backward-word))))
          (when (boundp 'evil-ex-search-keymap)
            (cond
             ((and (not value)


### PR DESCRIPTION
Fixes #1921

The test may be a lil hacky, and doesn't cover search or eval.