### PR TITLE
Fix pixel-scroll-precision-mode when point is on a blank line

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -970,7 +970,6 @@ Like `move-end-of-line', but retains the goal column."
 This behavior is controlled by `evil-move-beyond-eol'."
   (and (not evil-move-beyond-eol)
        (eolp)
-       (= (point) (save-excursion (evil-move-end-of-line) (point)))
        (evil-move-cursor-back t)))
 
 (defun evil-move-cursor-back (&optional force)


### PR DESCRIPTION
When in the point is on a blank line in normal state, scrolling down with `pixel-scroll-precision-mode` enabled "sticks" because Evil ends up invoking `line-move` in the `post-command-hook`. `line-move` resets vscroll to 0, which undoes the scroll if we scrolled less than a line.

Specifically, `evil-normal-post-command` calls `evil-adjust-cursor` which calls `evil-move-end-of-line` which calls `move-end-of-line`, which finally calls `line-move`.

This change avoids this issue by avoiding `evil-move-end-of-line` entirely, instead using `bolp` to check if we're already at the beginning of the line.

(note: I'm not sure if there were subtle reasons for calling `evil-move-end-of-line` here)

Upstream bug report: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=72323. But Evil probably shouldn't be calling `line-move` here anyways.