### PR TITLE
fix minibuffer abort from ex mode

### DIFF
--- a/evil-maps.el
+++ b/evil-maps.el
@@ -615,7 +615,7 @@ included in `evil-insert-state-bindings' by default."
 (define-key evil-command-line-map "\C-c" #'abort-recursive-edit)
 (define-key evil-command-line-map "\C-d" #'completion-at-point)
 (define-key evil-command-line-map "\C-f" 'evil-command-window)
-(define-key evil-command-line-map "\C-g" #'abort-minibuffers)
+(define-key evil-command-line-map "\C-g" #'abort-recursive-edit)
 (define-key evil-command-line-map "\C-k" 'evil-insert-digraph)
 (define-key evil-command-line-map "\C-l" #'completion-at-point)
 (define-key evil-command-line-map "\C-n" #'next-history-element)


### PR DESCRIPTION
### Bug report for what this fixes

<details>

```sh
eask install evil
eask emacs
```

```
M-x evil-mode
:C-g
```

Expected behaviour: no longer in ex mode. Experienced behaviour: error message `command-execute: Wrong type argument: commandp, abort-minibuffers`

</details>

### Testing Performed

<details>
I verified this fix locally via straight & eask, plopping this init.el into the .eask/init.el of my local checkout of the evil repository:

```elisp
(defvar bootstrap-version)
(let ((bootstrap-file
       (expand-file-name
        "straight/repos/straight.el/bootstrap.el"
        (or (bound-and-true-p straight-base-dir)
            user-emacs-directory)))
      (bootstrap-version 7))
  (unless (file-exists-p bootstrap-file)
    (with-current-buffer
        (url-retrieve-synchronously
         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
         'silent 'inhibit-cookies)
      (goto-char (point-max))
      (eval-print-last-sexp)))
  (load bootstrap-file nil 'nomessage))

(setq straight-use-package-by-default t)

(straight-use-package 'use-package)

(require 'use-package)

(use-package evil
  :straight '(evil
              :type git
              :flavor melpa
              :files (:defaults "doc/build/texinfo/evil.texi" (:exclude "evil-test-helpers.el") "evil-pkg.el")
              :host github
              :repo "emacs-evil/evil"
              :fork (:host github :repo "matthugs/evil")
              :branch "matthugs/fix-minibuffer-abort")
  :demand t
  :config (evil-mode 1))
```

</details>