### PR TITLE
Fix an issue where moving the cursor to end of the buffer would result in no visible text

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,0 @@
-;; Don't use tabs for el files
-((emacs-lisp-mode .
-   ((indent-tabs-mode . nil))))

--- a/evil-commands.el
+++ b/evil-commands.el
@@ -254,7 +254,18 @@ of the current screen line."
   :type line
   (evil-ensure-column
     (if (null count)
-        (goto-char (point-max))
+        (progn
+          (goto-char (point-max))
+          (when (and (eq (current-buffer) (window-buffer))
+                     (> (point) (window-end nil t)))
+            ;; When the user sets `scroll-conservatively` to a value greater
+            ;; than 100, moving the cursor to `(point-max)` with
+            ;; `(evil-goto-line nil)` can result in all text being located above
+            ;; the window start, preventing the user from seeing it.
+            ;;
+            ;; The following addresses this issue:
+            (overlay-recenter (point))
+            (recenter -1)))
       (goto-char (point-min))
       (forward-line (1- count)))))
 


### PR DESCRIPTION
This pull request fixes an issue where using `(evil-goto-line nil)` to move the cursor to the end of the buffer would result in no visible text because of `(goto-char (point-max))`.

This issue is difficult to reproduce because it doesn't always occur. I was fortunate enough to encounter it today, and the provided patch fixes the problem. This patch draws inspiration from the built-in `(end-of-buffer)` function, which does not exhibit the same issue as calling `(evil-goto-line nil)`.