### PR TITLE
Fix touch screen gestures (e.g., scrolling) for Emacs 30

### DIFF
--- a/evil-commands.el
+++ b/evil-commands.el
@@ -4903,6 +4903,11 @@ START-EVENT should be the event that started the drag."
   (evil-mouse-drag-track start-event t))
 (evil-set-command-property 'evil-mouse-drag-region :keep-visual t)
 
+;; Make sure `touch-screen-handle-touch' processes touch screen gestures by
+;; ignoring `evil-mouse-drag-region' (bound to `down-mouse-1') during mouse
+;; click emulation.
+(put 'evil-mouse-drag-region 'ignored-mouse-command t)
+
 (defun evil-mouse-drag-track (start-event &optional
                                           do-mouse-drag-region-post-process)
   "Track mouse drags by highlighting area between point and cursor.


### PR DESCRIPTION
Emacs 30 introduces improved touch-screen support (via the Android port), see “Touchscreen Events” in the Emacs Lisp reference manual: By default, touch screen gestures are not processed when a command is bound to `down-mouse-1` (as `evil-mouse-drag-region` is), as that is taken as an indication that touch input should be translated to `down-mouse-1` followed by mouse motion events.

This change applies the `ignored-mouse-command` property to `evil-mouse-drag-region` that is also present on `mouse-drag-region` in Emacs 30.  This has the effect that touch screen gestures are prioritized and mouse events are only emitted when no gesture was detected.