### PR TITLE
Make evil-shift-width safe as local variable

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -175,6 +175,7 @@ The number of columns by which a line is shifted.
 This applies to the shifting operators \\[evil-shift-right] and \
 \\[evil-shift-left]."
   :type 'integer
+  :safe #'integerp
   :group 'evil)
 
 (defcustom evil-shift-round t


### PR DESCRIPTION
The new editorconfig-mode in Emacs 30 automatically sets evil-shift-width ([here](https://github.com/emacsmirror/emacs/blob/8d687695c528e4edb04cca5602470d349e333258/lisp/editorconfig.el#L465)), but a popup window is shown every time because this variable is not marked safe as a local variable. This PR marks it safe to get rid of this annoyance.