### PR TITLE
Fix Emacs warnings

### DIFF
--- a/evil-vars.el
+++ b/evil-vars.el
@@ -559,11 +559,11 @@ ubiquity of prefix arguments."
            (cond
             ((and (not value)
                   (eq (lookup-key evil-command-line-map (kbd "C-w"))
-                      #'evil-delete-backward-word))
+                      'evil-delete-backward-word))
              (define-key evil-command-line-map (kbd "C-w") nil))
             ((and value
                   (null (lookup-key evil-command-line-map (kbd "C-w"))))
-             (define-key evil-command-line-map (kbd "C-w") #'evil-delete-backward-word))))
+             (define-key evil-command-line-map (kbd "C-w") 'evil-delete-backward-word))))
          (when (boundp 'evil-ex-search-keymap)
            (cond
             ((and (not value)


### PR DESCRIPTION
```
 »  Warning (comp): evil-vars.el:561:25: Warning: the function `evil-delete-backward-word' is not known to be defined.
 »  Warning (comp): evil-vars.el:565:25: Warning: the function `evil-delete-backward-word' is not known to be defined.
```