### PR TITLE
Fixes #1974: Correct C-h behavior to ensure electric-pair deletes adjacent pairs

### DIFF
--- a/evil-maps.el
+++ b/evil-maps.el
@@ -447,7 +447,7 @@
     ,@(when evil-want-C-u-delete
         '(("\C-u" . evil-delete-back-to-indentation)))
     ,@(when evil-want-C-h-delete
-        '(("\C-h" . evil-delete-backward-char-and-join)))
+        `(("\C-h" . ,(kbd "DEL"))))
     ([mouse-2] . mouse-yank-primary))
   "Evil's bindings for insert & replace states.
 Used in `evil-insert-state-map' and `evil-replace-state-map',

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -590,8 +590,7 @@ ubiquity of prefix arguments."
                (define-key evil-replace-state-map (kbd "C-h") nil))
               ((and value
                     (not (lookup-key evil-insert-state-map (kbd "C-h"))))
-               (define-key evil-insert-state-map (kbd "C-h")
-                           'evil-delete-backward-char-and-join)
+               (define-key evil-insert-state-map (kbd "C-h") (kbd "DEL"))
                (define-key evil-replace-state-map (kbd "C-h")
                            'evil-replace-backspace))))))
 


### PR DESCRIPTION
When using `electric-pair-mode`, the expected behavior when pressing `C-h` near a pair of adjacent delimiters (e.g., `()` `[]` `{}` `""`) is that both the opening and closing delimiters should be deleted together if they were inserted as a pair.

This pull request fixes #1974.

This pull request corrects `C-h` behavior to ensure electric-pair deletes adjacent pairs. It calls the same function as `DEL` (code 127) in `electric-pair-mode-map`:
```
electric-pair-mode-map is a variable defined in ‘elec-pair.el’.

Its value is
(keymap 
 (127 menu-item "" electric-pair-delete-pair :filter
  #f(compiled-function (cmd) #<bytecode 0x115035a9952592b3>)))
```

This pull request could be improved. Please don't hesitate to comment it if you have any suggestions.