### PR TITLE
fix: Warning missing lexical-binding cookie

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "evil"
          "1.15.0"
          "Extensible vi layer")


### PR DESCRIPTION
Fix snapshot warning:

```
You can add one with ‘M-x elisp-enable-lexical-binding RET’.
See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
for more information.
```