### PR TITLE
Fix evil-up-paren for Emacs 31

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1355,7 +1355,7 @@ last successful match (that caused COUNT to reach zero)."
   ;; Always use the default `forward-sexp-function'. This is important
   ;; for modes that use a custom one like `python-mode'.
   ;; (addresses #364)
-  (let (forward-sexp-function)
+  (let (forward-sexp-function up-list-function)
     (with-syntax-table (copy-syntax-table (syntax-table))
       (modify-syntax-entry open (format "(%c" close))
       (modify-syntax-entry close (format ")%c" open))


### PR DESCRIPTION
Fix #1993 

Emacs 31 introduces [up-list-function](https://github.com/emacs-mirror/emacs/blob/3cc34865e85328b9f2eeb998662fb2635c281add/lisp/emacs-lisp/lisp.el#L242) which is used in `treesit`, so we need to overrides it too to make the `up-list` calls in `evil-up-paren` work as intended.