### PR TITLE
Fix input method processing

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -436,13 +436,18 @@ This allows input methods to be used in normal-state."
 (defun evil--refresh-input-method (orig-fun &rest args)
   "Refresh `evil-input-method'."
   (cond
+   (isearch-mode
+    (apply orig-fun args))
    ((not evil-local-mode)
     (apply orig-fun args))
    ((evil-state-property evil-state :input-method)
     (apply orig-fun args))
    (t
-    (let ((current-input-method evil-input-method))
-      (apply orig-fun args)))))
+    (evil-without-input-method-hooks
+      (activate-input-method evil-input-method)
+      (apply orig-fun args)
+      (setq evil-input-method current-input-method)
+      (deactivate-input-method)))))
 
 ;; Local keymaps are implemented using buffer-local variables.
 ;; However, unless a buffer-local value already exists,

--- a/evil-core.el
+++ b/evil-core.el
@@ -1279,7 +1279,7 @@ If ARG is nil, don't display a message in the echo area.%s" name doc)
                                  ',state evil-previous-state)
              (let ((evil-state ',state))
                (evil-normalize-keymaps)
-               (if ',input-method
+               (if (evil-state-property evil-state :input-method)
                    (activate-input-method evil-input-method)
                  ;; BUG #475: Deactivate the current input method only
                  ;; if there is a function to deactivate it, otherwise

--- a/evil-search.el
+++ b/evil-search.el
@@ -92,6 +92,7 @@ To swap out relevant keybindings, see `evil-select-search-module' function."
            (isearch-forward regexp-p)
          (isearch-backward regexp-p))
        (evil-push-search-history isearch-string forward)
+       (setq evil-input-method current-input-method)
        (deactivate-input-method))
       (when (/= (point) point)
         ;; position the point at beginning of the match only if the call to

--- a/evil-search.el
+++ b/evil-search.el
@@ -87,12 +87,12 @@ To swap out relevant keybindings, see `evil-select-search-module' function."
       (evil-without-input-method-hooks
        ;; set the input method locally rather than globally to ensure that
        ;; isearch clears the input method when it's finished
-       (setq current-input-method evil-input-method)
+       (activate-input-method evil-input-method)
        (if forward
            (isearch-forward regexp-p)
          (isearch-backward regexp-p))
        (evil-push-search-history isearch-string forward)
-       (setq current-input-method nil))
+       (deactivate-input-method))
       (when (/= (point) point)
         ;; position the point at beginning of the match only if the call to
         ;; `isearch' has really moved the point. `isearch' doesn't move the


### PR DESCRIPTION
1. Do not set or locally bind current-input-method. This is dangerous and may prevent the input method from being properly activated or deactivated. We should use activate-input-method/deactivate-input-method instead.

We can find some related issues:

- https://github.com/emacs-evil/evil/issues/278
- https://github.com/emacs-evil/evil/issues/578
- https://github.com/emacs-evil/evil/issues/1156
- https://github.com/emacs-evil/evil/issues/1834

2. The mode enable functions should respect the user's modifications to the :input-method property in evil-state-properties.