### PR TITLE
Fix jump-list buffer mode-name and select-action.

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3783,6 +3783,7 @@ should be left-aligned for left justification."
 ;;; View helper
 
 (defvar-local evil-list-view-select-action nil)
+(put 'evil-list-view-select-action 'permanent-local t)
 
 (define-derived-mode evil-list-view-mode tabulated-list-mode
   "Evil List View"
@@ -3827,8 +3828,8 @@ PROPERTIES is a property-list which supports the following properties:
        (with-current-buffer buf
          (setq tabulated-list-format ,(plist-get properties :format))
          (setq tabulated-list-entries ,(plist-get properties :entries))
-         (setq evil-list-view-select-action ,(plist-get properties :select-action))
          (evil-list-view-mode)
+         (setq evil-list-view-select-action ,(plist-get properties :select-action))
          (setq mode-name ,(plist-get properties :mode-name))
          (evil-motion-state))
        (switch-to-buffer-other-window buf))))

--- a/evil-jumps.el
+++ b/evil-jumps.el
@@ -199,7 +199,7 @@ Otherwise the jump commands act only within the current buffer."
   :repeat nil
   (evil-with-view-list
     :name "evil-jumps"
-    :mode "Evil Jump List"
+    :mode-name "Evil Jump List"
     :format [("Jump" 5 nil)
              ("Marker" 8 nil)
              ("File/text" 1000 t)]


### PR DESCRIPTION
The property for the `mode-name` is `:mode-name` in `evil-common.el`, but `:mode` in `evil-jumps.el`. Changed it in `evil-jumps.el`, so that the `mode-name` in jump-list buffers is set correct.

For local variables, they are killed if a major-mode gets set, if the variable is not marked as `permanent-local`.
See `(info "(emacs) Locals")`:

> M-x kill-local-variable makes a specified variable cease to be local to the current buffer. The global value of the variable henceforth is in effect in this buffer. Setting the major mode kills all the local variables of the buffer except for a few variables specially marked as permanent locals.

Since all the variables in `tabulated-list` are marked as permanent locals, I marked `evil-list-view-select-action` as well. In addition, I moved the initialization of `evil-list-view-select-action` after switching to `evil-list-view-mode`, just to be sure.

This also fixes the `:select-action` of `evil-show-marks` buffers.