### PR TITLE
Improve evil-repeat compatibility with company-mode

### DIFF
--- a/evil-integration.el
+++ b/evil-integration.el
@@ -194,7 +194,10 @@
            '(company-complete-mouse
              company-complete-number
              company-complete-selection
-             company-complete-common))
+             company-complete-common
+             ;; Calling company-complete twice modifies the buffer; this need to
+             ;; be recorded.
+             company-complete))
 
      (mapc #'evil-declare-ignore-repeat
            '(company-abort

--- a/evil-integration.el
+++ b/evil-integration.el
@@ -208,8 +208,16 @@
              company-select-mouse
              company-show-doc-buffer
              company-show-location
+             company-filter-candidates
+             ;; Ignore keystrokes when `company-search-mode' is active
              company-search-candidates
-             company-filter-candidates))))
+             company-search-printing-char
+             company-search-other-char
+             company-search-toggle-filtering
+             company-search-repeat-forward
+             company-search-repeat-backward
+             company-search-abort
+             company-search-delete-char))))
 
 ;;; Eval last sexp
 (defun evil--preceding-sexp (command &rest args)


### PR DESCRIPTION
This PR addresses two specific issues where company-mode interactions interfere with evil repeat recordings.

1- When filtering candidates using `company-search-mode`, the internal navigation and filtering keystrokes (like printing characters, backspacing, or aborting) should not be recorded by Evil. If recorded, using the dot command `.` later attempts to replay the search interaction, which produces incorrect text.

2- When `company-complete` is called a second time, it modifies the buffer. This change needs to be explicitly recorded for `evil-repeat`. Without this fix, `company-pseudo-tooltip-frontend` interferes with the repeat logic, causing the repeat command to fail or behave unexpectedly.
