### PR TITLE
Fixes for evil-want-minibuffer

### DIFF
--- a/evil-core.el
+++ b/evil-core.el
@@ -111,6 +111,11 @@
 (declare-function evil-emacs-state-p "evil-states")
 (declare-function evil-ex-p "evil-ex")
 
+(defun evil--wcf-refresh-cursor (&rest _)
+  "Wrapper around `evil-refresh-cursor' that discards its arguments.
+This function is intended for use in the `window-*-change-functions` hooks."
+  (evil-refresh-cursor))
+
 (define-minor-mode evil-local-mode
   "Minor mode for setting up Evil in a single buffer."
   :init-value nil
@@ -128,8 +133,18 @@
         (add-hook 'activate-mark-hook 'evil-visual-activate-hook nil t)
         ;; FIXME: Add these hooks buffer-locally and remove when disabling
         (add-hook 'pre-command-hook 'evil-repeat-pre-hook)
-        (add-hook 'post-command-hook 'evil-repeat-post-hook))
+        (add-hook 'post-command-hook 'evil-repeat-post-hook)
+        ;; Cursor color can only be set for each frame but not for each buffer
+        ;; (Emacs bug#24153), so we need to refresh the cursor color whenever
+        ;; the selected window or its buffer changes.
+        ;;
+        ;; Emacs < 27 is handled further below using `select-window' advice.
+        (when (eval-when-compile (>= emacs-major-version 27))
+          (add-hook 'window-buffer-change-functions #'evil--wcf-refresh-cursor nil t)
+          (add-hook 'window-selection-change-functions #'evil--wcf-refresh-cursor nil t)))
     (evil-refresh-mode-line)
+    (remove-hook 'window-selection-change-functions #'evil--wcf-refresh-cursor t)
+    (remove-hook 'window-buffer-change-functions #'evil--wcf-refresh-cursor t)
     (remove-hook 'activate-mark-hook 'evil-visual-activate-hook t)
     (remove-hook 'input-method-activate-hook #'evil-activate-input-method t)
     (remove-hook 'input-method-deactivate-hook #'evil-deactivate-input-method t)
@@ -336,6 +351,7 @@ then this function does nothing."
 ;; run. This is appropriate since many buffers are used for throwaway
 ;; purposes. Passing the buffer to `set-window-buffer' indicates
 ;; otherwise, though, so advise this function to initialize Evil.
+;; FIXME: Use `window-buffer-change-functions' instead of advice in Emacs >= 27.
 (evil--advice-add 'set-window-buffer :before #'evil--swb-initialize)
 (defun evil--swb-initialize (_window buffer &rest _)
   "Initialize Evil in the displayed buffer."
@@ -344,13 +360,11 @@ then this function does nothing."
       (unless evil-local-mode
         (save-match-data (evil-initialize))))))
 
-;; Refresh cursor color.
-;; Cursor color can only be set for each frame but not for each buffer.
-;; FIXME: Shouldn't this belong in `evil-(local-)mode'?
-(add-hook 'window-configuration-change-hook #'evil-refresh-cursor)
-(advice-add 'select-window :after #'evil--sw-refresh-cursor)
-(defun evil--sw-refresh-cursor (&rest _)
-  (evil-refresh-cursor))
+;; We need advice to refresh the cursor color in Emacs < 27. Newer versions are
+;; handled in `evil-local-mode' above.
+(when (eval-when-compile (< emacs-major-version 27))
+  (add-hook 'window-configuration-change-hook #'evil-refresh-cursor)
+  (advice-add 'select-window :after #'evil--wcf-refresh-cursor))
 
 (defun evil-generate-mode-line-tag (&optional state)
   "Generate the evil mode-line tag for STATE."

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -2054,12 +2054,7 @@ This variable must be set before evil is loaded."
 (defcustom evil-want-minibuffer nil
   "Whether to enable Evil in minibuffer(s)."
   :type 'boolean
-  :group 'evil
-  :set #'(lambda (sym value)
-           (set-default sym value)
-           (if value
-               (add-hook 'minibuffer-setup-hook 'evil-initialize)
-             (remove-hook 'minibuffer-setup-hook 'evil-initialize))))
+  :group 'evil)
 
 (defun evil--redo-placeholder (_count)
   (user-error "Customize `evil-undo-system' for redo functionality."))


### PR DESCRIPTION
This fixes two issues with `evil-want-minibuffer` set to `t`:

### The cursor is not refreshed after initializing evil in the minibuffer

This can be observed when the initial state in the minibuffer (defaults to insert state in the minibuffer) has a different cursor color than the cursor that was active previously. I don't observe the effect of this bug in every use of the minibuffer (because sometimes a refresh will be triggered by other events), but ironically, I observe it in evil-ex.

I tracked this down to the following series of events:

1.  `evil-ex` calls `read-from-minibuffer`
2. `read-from-minibuffer` creates a fresh buffer (to become the minibuffer) and changes its major mode to `minibuffer-mode`
3. This triggers `after-change-major-mode-hook` which calls `evil-initialize`
4. `evil-initialize` does not abort even though `(minibufferp)` because `evil-want-minibuffer` is set, and so it calls `evil-local-mode`
5. `evil-local-mode` skips `evil-refresh-cursor` because the currently selected window does not (yet) display the minibuffer. More precisely, `(when (eq (window-buffer) (current-buffer))` is `nil`. (This check has been added in https://github.com/emacs-evil/evil/pull/1910, and it's correct.)
6. `read-from-minibuffer` makes the minibuffer window the selected window. But because everything happens in C, this bypasses our advice for `select-window` that is supposed to refresh the cursor.
7. (`evil-initialize` will be called again from `minibuffer-setup-hooks` but `evil-change-state` will correctly determine that we're already in the right state and skip further processing, including a potential cursor refresh.)

The first commit fixes this, at least in Emacs >= 27, by using the new `window-*-change-function` hooks instead of advice. This also makes it possible to handle the cursor refresh in `evil-local-mode`, which will disable it correctly when disabling evil. The latter fixes a `FIXME`.

### `evil-initialize` is called twice in minibuffer

See item 7 above. This is fixed by the second commit. Afterward, the minibuffer will be treated like every other buffer for evil purposes (if `evil-want-minibuffer` is set). 