### PR TITLE
Add Neovim-style visual word search

### DIFF
--- a/evil-search.el
+++ b/evil-search.el
@@ -274,7 +274,8 @@ one more than the current position."
       (evil-flash-search-pattern string t))))
 
 (defun evil-search-word (forward unbounded symbol)
-  "Search for word near point.
+  "Search for text in visual selection if in visual mode
+otherwise search for word near point.
 If FORWARD is nil, search backward, otherwise forward. If SYMBOL
 is non-nil then the functions searches for the symbol at point,
 otherwise for the word at point."
@@ -288,7 +289,9 @@ otherwise for the word at point."
            (not (string= string "")))
       (evil-search string forward t))
      (t
-      (setq string (evil-find-thing forward (if symbol 'symbol 'evil-word)))
+      (setq string (evil-find-thing-or-visual-selection
+                    forward
+                    (if symbol 'symbol 'evil-word)))
       (cond
        ((null string)
         (user-error "No word under point"))
@@ -327,6 +330,23 @@ THING should be a symbol understood by `thing-at-point',
 e.g. `symbol' or `word'.  If FORWARD is nil, search backward,
 otherwise forward.  Returns nil if nothing is found."
   (car (evil--find-thing forward thing)))
+
+(defun evil-find-thing-or-visual-selection (forward symbol)
+  "Return text in visual selection if in visual mode and
+if `evil-ex-search-nvim-visual-word-search' is set to t,
+otherwise return evil-find-thing with FORWARD and SYMBOL as
+parameters"
+  (let (string)
+    (if (and
+          evil-ex-search-nvim-visual-word-search
+          (evil-visual-state-p))
+        (progn
+          (setq string (substring-no-properties
+                        (buffer-substring (region-beginning)
+                                          (1+ (region-end)))))
+          (evil-exit-visual-state)
+          string)
+      (evil-find-thing forward (if symbol 'symbol 'evil-word)))))
 
 (defun evil-find-word (forward)
   "Return word near point as a string.

--- a/evil-vars.el
+++ b/evil-vars.el
@@ -1316,6 +1316,14 @@ highlighted."
   :type 'boolean
   :group 'evil)
 
+(defcustom evil-ex-search-nvim-visual-word-search nil
+  "If t enable neovim-style visual search when calling
+`evil-search-word' i.e. selected text in visual mode shall be
+searched instead of `thing-at-point', otherwise search for
+`thing-at-point'"
+  :type 'boolean
+  :group 'evil)
+
 (defcustom evil-ex-substitute-highlight-all t
   "If t all matches for the substitute pattern are highlighted."
   :type 'boolean


### PR DESCRIPTION
As the title suggests.

It is not a 100% imitation of Neovim though because `{Visual}*` will not place the word boundaries around selection.

So, for example, if you press `*` on the following text `he[llo wo]rld` (the `[` and `]` shall represent the visually selected text) it shall search for `\<llo wo\>` instead of `llo wo` (for that you can use `g*` which does not exist as a visual mode keybind in Neovim)

If you prefer I can create a variable which follows 100% Neovim's behavior (although, in my humble opinion, I think this behavior is better)