### PR TITLE
Fix disabling the cursor 

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -731,10 +731,12 @@ filename."
   "Change the cursor's apperance according to SPECS.
 SPECS may be a cursor type as per `cursor-type', a color
 string as passed to `set-cursor-color', a zero-argument
-function for changing the cursor, or a list of the above."
-  (unless (and (not (functionp specs))
-               (listp specs)
-               (null (cdr-safe (last specs))))
+function for changing the cursor, or a non-empty list of the above."
+  ;; if it's a single spec, wrap it in a list
+  (when (or (functionp specs)
+            (null specs)
+            (not (listp specs))
+            (cdr-safe (last specs)))
     (setq specs (list specs)))
   (dolist (spec specs)
     (cond


### PR DESCRIPTION
Without this, evil-set-cursor treats nil as an empty list of specs (i.e., a noop). But nil is a valid single spec; namely it's a valid value of the cursor-type variable, which means "don't show a cursor".

This also inverts rewrites the logic to use (when (or ...)) instead of (unless (and ...)) because that's much more readable, at least to me.

Fixes #592.