### PR TITLE
Fixes #2021: Fix 'wrong-type-argument wholenump' in evil-line-move

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -1255,9 +1255,10 @@ Signal an error at buffer boundaries unless NOERROR is non-nil."
       (condition-case err
           (line-move count)
         ((beginning-of-buffer end-of-buffer)
-         (let ((col (or goal-column
-                        (car-safe temporary-goal-column)
-                        temporary-goal-column)))
+         (let* ((raw-col (or goal-column
+                             (car-safe temporary-goal-column)
+                             temporary-goal-column))
+                (col (if (numberp raw-col) (max 0 raw-col) 0)))
            (line-move-finish col opoint (< count 0)))
          (or noerror (/= (point) opoint) (signal (car err) (cdr err))))))))
 


### PR DESCRIPTION
When moving past the beginning of a buffer, evil-line-move can signal a wrong-type-argument wholenump error. This occurs when the visual column calculation results in a negative float for temporary-goal-column.

This pull request fixes #2021.