### PR TITLE
Use comment as fallback for evil-a-paren if no balanced block inside

### DIFF
--- a/evil-common.el
+++ b/evil-common.el
@@ -3176,6 +3176,11 @@ is ignored."
               (or (evil-with-restriction (car bnd) (cdr bnd)
                     (ignore-errors
                       (evil-select-block thing beg end type count inclusive)))
+                  (and (eq inclusive t)
+                       (or (null count) (= count 1))
+                       (= (char-after (car bnd)) open)
+                       (= (char-before (cdr bnd)) close)
+                       (evil-range (car bnd) (cdr bnd) type :expanded t))
                   (save-excursion
                     (setq beg (or beg (point))
                           end (or end (point)))


### PR DESCRIPTION
For example, in OCaml comments which are delimited by (* *), there can
be numbered lists which may contain unbalanced ")" characters.
evil-a-paren should still be able to select the enclosing comment if
it cannot find a balanced block inside the comment.

Unfortunately, this only works reasonably for count = 1.

Fix #2023.